### PR TITLE
[PROBE: energy] energy/latent-heat-et-consistency — latent heat and ET must describe one evaporation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,7 @@ long.
 | `mass/antecedent-monotonicity` | Zhi Li (CU Boulder) |
 | `mass/phase-counterfactual` | Zhi Li (CU Boulder) |
 | `energy/pet-consistency` | Zhi Li (CU Boulder) |
+| `energy/latent-heat-et-consistency` | Changming Li (SCUT) |
 | `momentum/routing-conservation` | Zhi Li (CU Boulder) |
 
 ## Models

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ unclaimed.
 | [`mass/antecedent-monotonicity`](probes/mass/antecedent-monotonicity) | mass | The same storm after a dry month and a wet one: the wetter catchment runs off more, and no more than the extra water. | `reference_cheater` |
 | [`mass/phase-counterfactual`](probes/mass/phase-counterfactual) | mass | The same water falling as rain instead of snow: timing moves, the integrated volumes may not. | `reference_sublimating` |
 | [`energy/pet-consistency`](probes/energy/pet-consistency) | energy | Evaporation reaches demand when the model's own soil is wettest, stays below it, and falls when the soil is driest. | `reference_thirsty` |
+| [`energy/latent-heat-et-consistency`](probes/energy/latent-heat-et-consistency) | energy | The evaporation a model reports as water and the evaporation implied by the latent heat it reports: are they the same evaporation? | `reference_two_head`, `reference_constant_lambda`, `reference_sublimation_blind`, `reference_energy_leak` |
 | [`momentum/routing-conservation`](probes/momentum/routing-conservation) | momentum | The channel store is never negative and never holds more than its hydrograph can. | `reference_stuck_router` |
 
 ## Models
@@ -104,18 +105,27 @@ physical models' runs are archived there too. A
 physical model is there to test the probes: the exact bucket, two
 hand-written conceptual models from
 [chrimerss/HydrologicModels](https://github.com/chrimerss/HydrologicModels)
-and the NWS's SAC-SMA with Snow-17 must pass every probe, so a probe that
-fails one is wrong until shown otherwise. A broken model is broken in one specific way, so that no criterion
+and the NWS's SAC-SMA with Snow-17 must pass every probe that can ask them
+anything, so a probe that fails one is wrong until shown otherwise. All four
+report water and no energy, so all four are INCOMPLETE on
+`energy/latent-heat-et-consistency` rather than passing it: they have not
+violated conservation of energy, they have declined to be falsifiable about
+it, exactly as `reference_streamflow_only` does on the budget probes. A broken model is broken in one specific way, so that no criterion
 goes untested.
 
 | Model | Kind | What it does | Standing |
 | --- | --- | --- | --- |
 | [`google_flood_forecast`](models/google_flood_forecast) | submitted | The mean-embedding forecast LSTM behind Google Flood Hub, at the published weights. Predicts discharge and nothing else. | **FAIL (INCOMPLETE)**, 5 of 14 probes passed. Runoff-only, so three budget probes cannot ask it anything; of the seven that ask on runoff alone it passes the runoff bounds, memory and area, and fails step, extreme rain, phase, and a 0.18 mm/day dip after an added storm |
 | [`dhbv2`](models/dhbv2) | submitted | δHBV 2.0, the MHPI group's differentiable HBV: neural networks write the parameters of a bucket model that reports its stores and its evaporation. | **FAIL (VIOLATION)**, 10 of 14 probes passed. Its learned regional-groundwater term, declared as `gwex`, closes the budget to 1e-8; what remains is a learned field capacity twice the catchment's, a response to doubled rain above the rain added, a runoff depth that changes with the area it is told, and a third more runoff when snow falls as rain |
-| `reference_bucket` | exact | conserves water exactly by construction | must pass every probe |
-| [`flex_lumped`](models/flex_lumped) | physical | lumped FLEX/HBV: interception, beta-partitioned unsaturated store, fast and slow reservoirs, triangular lag | must pass every probe; **PASS**, 14 of 14 |
-| [`flex_topo`](models/flex_topo) | physical | FLEX-Topo: plateau, hillslope and wetland units on real Wark fractions sharing one groundwater store | must pass every probe; **PASS**, 14 of 14 |
-| [`sacsma_snow17`](models/sacsma_snow17) | physical | the NWS's SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it | must pass every probe; **PASS**, 14 of 14 |
+| `reference_bucket` | exact | conserves water exactly by construction | must pass every probe that can ask it anything; INCOMPLETE on the energy probe, which needs fluxes it does not report |
+| [`flex_lumped`](models/flex_lumped) | physical | lumped FLEX/HBV: interception, beta-partitioned unsaturated store, fast and slow reservoirs, triangular lag | must pass every probe that can ask it anything; **PASS**, 14 of 15, INCOMPLETE on the energy probe |
+| [`flex_topo`](models/flex_topo) | physical | FLEX-Topo: plateau, hillslope and wetland units on real Wark fractions sharing one groundwater store | must pass every probe that can ask it anything; **PASS**, 14 of 15, INCOMPLETE on the energy probe |
+| [`sacsma_snow17`](models/sacsma_snow17) | physical | the NWS's SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it | must pass every probe that can ask it anything; **PASS**, 14 of 15, INCOMPLETE on the energy probe |
+| `reference_coupled` | exact | the bucket with snow sublimation and a surface energy budget: every kilogram converted at the latent heat of the phase it actually underwent | must pass every criterion of `energy/latent-heat-et-consistency` |
+| `reference_two_head` | broken | a water head and an energy head that never meet: both budgets close to 1e-15 and the latent heat implies an evaporation it never reported | caught by `flux_identity` |
+| `reference_constant_lambda` | broken | coherent, but converts every kilogram at the same latent heat of vaporisation | caught by `flux_identity` |
+| `reference_sublimation_blind` | broken | coherent for liquid water, but converts snow sublimation at the latent heat of vaporisation instead of sublimation | caught by `flux_identity` |
+| `reference_energy_leak` | broken | discards 15% of net radiation; the energy counterpart of `reference_leaky` | caught by `energy_closure` |
 | `reference_leaky` | broken | hides a silent 15% sink | caught by `closure` |
 | `reference_cheater` | broken | solves for storage as whatever balances the budget | caught by `state_bounds` |
 | `reference_degenerate` | broken | evaporates all precipitation, produces no runoff | caught by `non_degenerate`, `response_sign` |

--- a/models/reference_constant_lambda/ht_adapter.py
+++ b/models/reference_constant_lambda/ht_adapter.py
@@ -17,7 +17,7 @@ MODE = "constant_lambda"
 MODEL = {"name": "reference_constant_lambda", "version": "1.0.0"}
 
 COLUMNS = [
-    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "time", "pr", "evspsbl", "mrro", "sbl", "hfls", "hfss", "hfg",
     "mrso", "snw", "canopy", "channel",
 ]
 
@@ -137,6 +137,9 @@ def simulate(forcing, static, dt_days=1.0):
             "time": step["time"],
             "pr": pr_rate,
             "evspsbl": (liquid + sublimation) / dt_days,
+            # The sublimating share of the evaporation above, so a
+            # criterion never has to infer which kilograms left as ice.
+            "sbl": sublimation / dt_days,
             "mrro": (surface + baseflow) / dt_days,
             "hfls": latent,
             "hfss": sensible,

--- a/models/reference_constant_lambda/ht_adapter.py
+++ b/models/reference_constant_lambda/ht_adapter.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""HydroTuring adapter. Standard library only, to show that the /io contract
+needs no scientific Python stack and could be written in any language.
+
+Coherent, but converts every kilogram at the same latent heat.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+MODE = "constant_lambda"
+MODEL = {"name": "reference_constant_lambda", "version": "1.0.0"}
+
+COLUMNS = [
+    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "mrso", "snw", "canopy", "channel",
+]
+
+EVAP_SHAPE = 0.5   # soil moisture at which evaporation reaches its potential rate
+SUBL_SHARE = 0.35  # share of the remaining demand a snowpack can meet
+GROUND_SHARE = 0.10  # share of net radiation conducted into the ground
+
+# Latent heat of vaporisation as A + B*T (T in degC) and of fusion, J kg-1.
+LAMBDA_A, LAMBDA_B = 2.501e6, -2361.0
+LAMBDA_F = 3.337e5
+LAMBDA_CONST = 2.45e6  # the constant a careless model would use
+CLIMATOLOGICAL_EF = 0.65  # evaporative fraction of a model whose heads never meet
+ENERGY_LEAK = 0.15
+SECONDS_PER_DAY = 86400.0
+
+TIMESTEP_DAYS = {
+    "PT1D": 1.0,
+    "PT1H": 1.0 / 24.0,
+    "PT15M": 1.0 / 96.0,
+    "PT5M": 1.0 / 288.0,
+    "PT1M": 1.0 / 1440.0,
+}
+
+
+def partition_energy(rn, tas, liquid_mm, sublimated_mm, dt_days):
+    """Turn the water that left the surface into the energy that carried it.
+
+    `reference_coupled` is exact: every kilogram is converted at the latent
+    heat of the phase change it actually underwent, and the sensible flux is
+    what net radiation has left once the latent and ground fluxes are taken.
+    Solving for H that way is the physical statement that the surface has no
+    other place to put the energy, and it is why this model closes the energy
+    budget by construction, exactly as `reference_bucket` closes the water
+    budget by construction. The discrimination lives in the other four.
+    """
+    seconds = dt_days * SECONDS_PER_DAY
+    lam_v = LAMBDA_A + LAMBDA_B * tas
+    lam_s = LAMBDA_A + LAMBDA_F
+    ground = GROUND_SHARE * rn
+
+    if MODE == "constant_lambda":
+        latent = LAMBDA_CONST * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "sublimation_blind":
+        latent = lam_v * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "two_head":
+        # An energy head that never reads the water head: the partition is a
+        # climatological evaporative fraction of the available energy, and it
+        # has no idea how much water actually left.
+        latent = CLIMATOLOGICAL_EF * (rn - ground)
+    else:
+        latent = (lam_v * liquid_mm + lam_s * sublimated_mm) / seconds
+
+    sensible = rn - ground - latent
+    if MODE == "energy_leak":
+        sensible -= ENERGY_LEAK * rn
+    return latent, sensible, ground
+
+
+def simulate(forcing, static, dt_days=1.0):
+    """The reference bucket, with snow sublimation and a surface energy budget.
+
+    The water side is `reference_bucket` plus one term: a snowpack meets part
+    of the evaporative demand by sublimating, which is removed from the pack
+    like every other flux, so the water budget still closes to floating point.
+    That term exists because without it no step in the record has a phase
+    change to be coherent about.
+    """
+    soil_cap = static["soil_capacity_mm"]
+    canopy_cap = static["canopy_capacity_mm"]
+    ddf = static["degree_day_factor_mm_per_C_day"]
+    k_base = static["baseflow_coefficient"]
+    t_snow = static["snow_threshold_degC"]
+
+    soil = 0.5 * soil_cap
+    swe = 0.0
+    canopy = 0.0
+    rows = []
+
+    for step in forcing:
+        pr_rate, tas, pet_rate = step["pr"], step["tas"], step["pet"]
+        rn = step.get("rn", 0.0)
+        pr = pr_rate * dt_days
+        pet = pet_rate * dt_days
+
+        snowfall = pr if tas < t_snow else 0.0
+        rain = 0.0 if tas < t_snow else pr
+
+        swe += snowfall
+        melt = min(swe, ddf * max(tas - t_snow, 0.0) * dt_days)
+        swe -= melt
+
+        water_in = rain + melt
+        intercepted = min(canopy_cap - canopy, water_in)
+        canopy += intercepted
+        throughfall = water_in - intercepted
+
+        canopy_evap = min(canopy, pet)
+        canopy -= canopy_evap
+        pet_left = pet - canopy_evap
+
+        sublimation = min(swe, SUBL_SHARE * pet_left) if swe > 0.0 else 0.0
+        swe -= sublimation
+        pet_left -= sublimation
+
+        soil += throughfall
+        surface = max(0.0, soil - soil_cap)
+        soil -= surface
+        baseflow = k_base * soil * dt_days
+        soil -= baseflow
+        soil_evap = min(soil, pet_left * min(1.0, soil / (EVAP_SHAPE * soil_cap)))
+        soil -= soil_evap
+
+        liquid = canopy_evap + soil_evap
+        latent, sensible, ground = partition_energy(rn, tas, liquid, sublimation, dt_days)
+
+        rows.append({
+            "time": step["time"],
+            "pr": pr_rate,
+            "evspsbl": (liquid + sublimation) / dt_days,
+            "mrro": (surface + baseflow) / dt_days,
+            "hfls": latent,
+            "hfss": sensible,
+            "hfg": ground,
+            "mrso": soil,
+            "snw": swe,
+            "canopy": canopy,
+            # No routing: runoff leaves the stores and the catchment in the
+            # same step, so the water in transit is identically zero.
+            # Reported rather than omitted, because it is a statement.
+            "channel": 0.0,
+        })
+    return rows
+
+
+def read_request(path: Path) -> tuple[dict, Path]:
+    request = json.loads(path.read_text())
+    return request, path.parent
+
+
+def read_forcing(path: Path) -> list[dict]:
+    with open(path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    for row in rows:
+        for key in ("pr", "tas", "pet", "rn"):
+            if key in row:
+                row[key] = float(row[key])
+    return rows
+
+
+def write_result(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True)
+    args = parser.parse_args()
+
+    request_path = Path(args.request).resolve()
+    request, io_dir = read_request(request_path)
+    forcing = read_forcing(io_dir / request["input"]["forcing"])
+    static = json.loads((io_dir / request["input"]["static"]).read_text())
+
+    timestep = request.get("timestep", "PT1D")
+    if timestep not in TIMESTEP_DAYS:
+        raise SystemExit(f"unsupported timestep {timestep!r}")
+    rows = simulate(forcing, static, TIMESTEP_DAYS[timestep])
+
+    write_result(io_dir / request["output"]["table"], rows)
+    (io_dir / request["output"]["run"]).write_text(
+        json.dumps({"status": "ok", "model": MODEL, "n_steps": len(rows)}, indent=2)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/reference_constant_lambda/model.yaml
+++ b/models/reference_constant_lambda/model.yaml
@@ -12,7 +12,7 @@ runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
 timestep: [PT1D]
 emits:
-  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  fluxes: [pr, evspsbl, mrro, sbl, hfls, hfss, hfg]
   states: [mrso, snw, canopy, channel]
 needs_forcing: [pr, tas, pet, rn]
 supports:

--- a/models/reference_constant_lambda/model.yaml
+++ b/models/reference_constant_lambda/model.yaml
@@ -1,0 +1,20 @@
+name: reference_constant_lambda
+version: "1.0.0"
+description: >
+  Fully coupled and correct in every other respect, except that the latent
+  heat of vaporisation is a constant instead of a function of temperature.
+  The error reaches 3.4 percent over a -20 to +35 degC record, which is why
+  flux_identity is scored per step against a tolerance far tighter than the
+  suite's 5 percent rule. It exists to prove that tolerance is necessary.
+authors: ["HydroTuring maintainers"]
+license: PolyForm-Noncommercial-1.0.0
+runner: subprocess
+entrypoint: ["python3", "ht_adapter.py"]
+timestep: [PT1D]
+emits:
+  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  states: [mrso, snw, canopy, channel]
+needs_forcing: [pr, tas, pet, rn]
+supports:
+  perturbation: true
+resources: {cpu: 1, memory_gb: 1, gpu: false}

--- a/models/reference_coupled/ht_adapter.py
+++ b/models/reference_coupled/ht_adapter.py
@@ -17,7 +17,7 @@ MODE = "coupled"
 MODEL = {"name": "reference_coupled", "version": "1.0.0"}
 
 COLUMNS = [
-    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "time", "pr", "evspsbl", "mrro", "sbl", "hfls", "hfss", "hfg",
     "mrso", "snw", "canopy", "channel",
 ]
 
@@ -137,6 +137,9 @@ def simulate(forcing, static, dt_days=1.0):
             "time": step["time"],
             "pr": pr_rate,
             "evspsbl": (liquid + sublimation) / dt_days,
+            # The sublimating share of the evaporation above, so a
+            # criterion never has to infer which kilograms left as ice.
+            "sbl": sublimation / dt_days,
             "mrro": (surface + baseflow) / dt_days,
             "hfls": latent,
             "hfss": sensible,

--- a/models/reference_coupled/ht_adapter.py
+++ b/models/reference_coupled/ht_adapter.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""HydroTuring adapter. Standard library only, to show that the /io contract
+needs no scientific Python stack and could be written in any language.
+
+The exact model for the coherence probe: one evaporation, reported twice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+MODE = "coupled"
+MODEL = {"name": "reference_coupled", "version": "1.0.0"}
+
+COLUMNS = [
+    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "mrso", "snw", "canopy", "channel",
+]
+
+EVAP_SHAPE = 0.5   # soil moisture at which evaporation reaches its potential rate
+SUBL_SHARE = 0.35  # share of the remaining demand a snowpack can meet
+GROUND_SHARE = 0.10  # share of net radiation conducted into the ground
+
+# Latent heat of vaporisation as A + B*T (T in degC) and of fusion, J kg-1.
+LAMBDA_A, LAMBDA_B = 2.501e6, -2361.0
+LAMBDA_F = 3.337e5
+LAMBDA_CONST = 2.45e6  # the constant a careless model would use
+CLIMATOLOGICAL_EF = 0.65  # evaporative fraction of a model whose heads never meet
+ENERGY_LEAK = 0.15
+SECONDS_PER_DAY = 86400.0
+
+TIMESTEP_DAYS = {
+    "PT1D": 1.0,
+    "PT1H": 1.0 / 24.0,
+    "PT15M": 1.0 / 96.0,
+    "PT5M": 1.0 / 288.0,
+    "PT1M": 1.0 / 1440.0,
+}
+
+
+def partition_energy(rn, tas, liquid_mm, sublimated_mm, dt_days):
+    """Turn the water that left the surface into the energy that carried it.
+
+    `reference_coupled` is exact: every kilogram is converted at the latent
+    heat of the phase change it actually underwent, and the sensible flux is
+    what net radiation has left once the latent and ground fluxes are taken.
+    Solving for H that way is the physical statement that the surface has no
+    other place to put the energy, and it is why this model closes the energy
+    budget by construction, exactly as `reference_bucket` closes the water
+    budget by construction. The discrimination lives in the other four.
+    """
+    seconds = dt_days * SECONDS_PER_DAY
+    lam_v = LAMBDA_A + LAMBDA_B * tas
+    lam_s = LAMBDA_A + LAMBDA_F
+    ground = GROUND_SHARE * rn
+
+    if MODE == "constant_lambda":
+        latent = LAMBDA_CONST * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "sublimation_blind":
+        latent = lam_v * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "two_head":
+        # An energy head that never reads the water head: the partition is a
+        # climatological evaporative fraction of the available energy, and it
+        # has no idea how much water actually left.
+        latent = CLIMATOLOGICAL_EF * (rn - ground)
+    else:
+        latent = (lam_v * liquid_mm + lam_s * sublimated_mm) / seconds
+
+    sensible = rn - ground - latent
+    if MODE == "energy_leak":
+        sensible -= ENERGY_LEAK * rn
+    return latent, sensible, ground
+
+
+def simulate(forcing, static, dt_days=1.0):
+    """The reference bucket, with snow sublimation and a surface energy budget.
+
+    The water side is `reference_bucket` plus one term: a snowpack meets part
+    of the evaporative demand by sublimating, which is removed from the pack
+    like every other flux, so the water budget still closes to floating point.
+    That term exists because without it no step in the record has a phase
+    change to be coherent about.
+    """
+    soil_cap = static["soil_capacity_mm"]
+    canopy_cap = static["canopy_capacity_mm"]
+    ddf = static["degree_day_factor_mm_per_C_day"]
+    k_base = static["baseflow_coefficient"]
+    t_snow = static["snow_threshold_degC"]
+
+    soil = 0.5 * soil_cap
+    swe = 0.0
+    canopy = 0.0
+    rows = []
+
+    for step in forcing:
+        pr_rate, tas, pet_rate = step["pr"], step["tas"], step["pet"]
+        rn = step.get("rn", 0.0)
+        pr = pr_rate * dt_days
+        pet = pet_rate * dt_days
+
+        snowfall = pr if tas < t_snow else 0.0
+        rain = 0.0 if tas < t_snow else pr
+
+        swe += snowfall
+        melt = min(swe, ddf * max(tas - t_snow, 0.0) * dt_days)
+        swe -= melt
+
+        water_in = rain + melt
+        intercepted = min(canopy_cap - canopy, water_in)
+        canopy += intercepted
+        throughfall = water_in - intercepted
+
+        canopy_evap = min(canopy, pet)
+        canopy -= canopy_evap
+        pet_left = pet - canopy_evap
+
+        sublimation = min(swe, SUBL_SHARE * pet_left) if swe > 0.0 else 0.0
+        swe -= sublimation
+        pet_left -= sublimation
+
+        soil += throughfall
+        surface = max(0.0, soil - soil_cap)
+        soil -= surface
+        baseflow = k_base * soil * dt_days
+        soil -= baseflow
+        soil_evap = min(soil, pet_left * min(1.0, soil / (EVAP_SHAPE * soil_cap)))
+        soil -= soil_evap
+
+        liquid = canopy_evap + soil_evap
+        latent, sensible, ground = partition_energy(rn, tas, liquid, sublimation, dt_days)
+
+        rows.append({
+            "time": step["time"],
+            "pr": pr_rate,
+            "evspsbl": (liquid + sublimation) / dt_days,
+            "mrro": (surface + baseflow) / dt_days,
+            "hfls": latent,
+            "hfss": sensible,
+            "hfg": ground,
+            "mrso": soil,
+            "snw": swe,
+            "canopy": canopy,
+            # No routing: runoff leaves the stores and the catchment in the
+            # same step, so the water in transit is identically zero.
+            # Reported rather than omitted, because it is a statement.
+            "channel": 0.0,
+        })
+    return rows
+
+
+def read_request(path: Path) -> tuple[dict, Path]:
+    request = json.loads(path.read_text())
+    return request, path.parent
+
+
+def read_forcing(path: Path) -> list[dict]:
+    with open(path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    for row in rows:
+        for key in ("pr", "tas", "pet", "rn"):
+            if key in row:
+                row[key] = float(row[key])
+    return rows
+
+
+def write_result(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True)
+    args = parser.parse_args()
+
+    request_path = Path(args.request).resolve()
+    request, io_dir = read_request(request_path)
+    forcing = read_forcing(io_dir / request["input"]["forcing"])
+    static = json.loads((io_dir / request["input"]["static"]).read_text())
+
+    timestep = request.get("timestep", "PT1D")
+    if timestep not in TIMESTEP_DAYS:
+        raise SystemExit(f"unsupported timestep {timestep!r}")
+    rows = simulate(forcing, static, TIMESTEP_DAYS[timestep])
+
+    write_result(io_dir / request["output"]["table"], rows)
+    (io_dir / request["output"]["run"]).write_text(
+        json.dumps({"status": "ok", "model": MODEL, "n_steps": len(rows)}, indent=2)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/reference_coupled/model.yaml
+++ b/models/reference_coupled/model.yaml
@@ -1,0 +1,23 @@
+name: reference_coupled
+version: "1.0.0"
+description: >
+  The bucket of reference_bucket with snow sublimation and a surface energy
+  budget. Every kilogram of water that leaves the surface is converted to
+  latent heat at the latent heat of the phase change it actually underwent,
+  so the water budget, the energy budget and the identity between them all
+  hold by construction. It is the model every criterion of
+  energy/latent-heat-et-consistency must pass. If it ever fails one, the
+  criterion has drifted past what exact physics achieves and the criterion
+  is wrong rather than the model.
+authors: ["HydroTuring maintainers"]
+license: PolyForm-Noncommercial-1.0.0
+runner: subprocess
+entrypoint: ["python3", "ht_adapter.py"]
+timestep: [PT1D]
+emits:
+  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  states: [mrso, snw, canopy, channel]
+needs_forcing: [pr, tas, pet, rn]
+supports:
+  perturbation: true
+resources: {cpu: 1, memory_gb: 1, gpu: false}

--- a/models/reference_coupled/model.yaml
+++ b/models/reference_coupled/model.yaml
@@ -15,7 +15,7 @@ runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
 timestep: [PT1D]
 emits:
-  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  fluxes: [pr, evspsbl, mrro, sbl, hfls, hfss, hfg]
   states: [mrso, snw, canopy, channel]
 needs_forcing: [pr, tas, pet, rn]
 supports:

--- a/models/reference_energy_leak/ht_adapter.py
+++ b/models/reference_energy_leak/ht_adapter.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""HydroTuring adapter. Standard library only, to show that the /io contract
+needs no scientific Python stack and could be written in any language.
+
+Discards 15 percent of net radiation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+MODE = "energy_leak"
+MODEL = {"name": "reference_energy_leak", "version": "1.0.0"}
+
+COLUMNS = [
+    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "mrso", "snw", "canopy", "channel",
+]
+
+EVAP_SHAPE = 0.5   # soil moisture at which evaporation reaches its potential rate
+SUBL_SHARE = 0.35  # share of the remaining demand a snowpack can meet
+GROUND_SHARE = 0.10  # share of net radiation conducted into the ground
+
+# Latent heat of vaporisation as A + B*T (T in degC) and of fusion, J kg-1.
+LAMBDA_A, LAMBDA_B = 2.501e6, -2361.0
+LAMBDA_F = 3.337e5
+LAMBDA_CONST = 2.45e6  # the constant a careless model would use
+CLIMATOLOGICAL_EF = 0.65  # evaporative fraction of a model whose heads never meet
+ENERGY_LEAK = 0.15
+SECONDS_PER_DAY = 86400.0
+
+TIMESTEP_DAYS = {
+    "PT1D": 1.0,
+    "PT1H": 1.0 / 24.0,
+    "PT15M": 1.0 / 96.0,
+    "PT5M": 1.0 / 288.0,
+    "PT1M": 1.0 / 1440.0,
+}
+
+
+def partition_energy(rn, tas, liquid_mm, sublimated_mm, dt_days):
+    """Turn the water that left the surface into the energy that carried it.
+
+    `reference_coupled` is exact: every kilogram is converted at the latent
+    heat of the phase change it actually underwent, and the sensible flux is
+    what net radiation has left once the latent and ground fluxes are taken.
+    Solving for H that way is the physical statement that the surface has no
+    other place to put the energy, and it is why this model closes the energy
+    budget by construction, exactly as `reference_bucket` closes the water
+    budget by construction. The discrimination lives in the other four.
+    """
+    seconds = dt_days * SECONDS_PER_DAY
+    lam_v = LAMBDA_A + LAMBDA_B * tas
+    lam_s = LAMBDA_A + LAMBDA_F
+    ground = GROUND_SHARE * rn
+
+    if MODE == "constant_lambda":
+        latent = LAMBDA_CONST * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "sublimation_blind":
+        latent = lam_v * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "two_head":
+        # An energy head that never reads the water head: the partition is a
+        # climatological evaporative fraction of the available energy, and it
+        # has no idea how much water actually left.
+        latent = CLIMATOLOGICAL_EF * (rn - ground)
+    else:
+        latent = (lam_v * liquid_mm + lam_s * sublimated_mm) / seconds
+
+    sensible = rn - ground - latent
+    if MODE == "energy_leak":
+        sensible -= ENERGY_LEAK * rn
+    return latent, sensible, ground
+
+
+def simulate(forcing, static, dt_days=1.0):
+    """The reference bucket, with snow sublimation and a surface energy budget.
+
+    The water side is `reference_bucket` plus one term: a snowpack meets part
+    of the evaporative demand by sublimating, which is removed from the pack
+    like every other flux, so the water budget still closes to floating point.
+    That term exists because without it no step in the record has a phase
+    change to be coherent about.
+    """
+    soil_cap = static["soil_capacity_mm"]
+    canopy_cap = static["canopy_capacity_mm"]
+    ddf = static["degree_day_factor_mm_per_C_day"]
+    k_base = static["baseflow_coefficient"]
+    t_snow = static["snow_threshold_degC"]
+
+    soil = 0.5 * soil_cap
+    swe = 0.0
+    canopy = 0.0
+    rows = []
+
+    for step in forcing:
+        pr_rate, tas, pet_rate = step["pr"], step["tas"], step["pet"]
+        rn = step.get("rn", 0.0)
+        pr = pr_rate * dt_days
+        pet = pet_rate * dt_days
+
+        snowfall = pr if tas < t_snow else 0.0
+        rain = 0.0 if tas < t_snow else pr
+
+        swe += snowfall
+        melt = min(swe, ddf * max(tas - t_snow, 0.0) * dt_days)
+        swe -= melt
+
+        water_in = rain + melt
+        intercepted = min(canopy_cap - canopy, water_in)
+        canopy += intercepted
+        throughfall = water_in - intercepted
+
+        canopy_evap = min(canopy, pet)
+        canopy -= canopy_evap
+        pet_left = pet - canopy_evap
+
+        sublimation = min(swe, SUBL_SHARE * pet_left) if swe > 0.0 else 0.0
+        swe -= sublimation
+        pet_left -= sublimation
+
+        soil += throughfall
+        surface = max(0.0, soil - soil_cap)
+        soil -= surface
+        baseflow = k_base * soil * dt_days
+        soil -= baseflow
+        soil_evap = min(soil, pet_left * min(1.0, soil / (EVAP_SHAPE * soil_cap)))
+        soil -= soil_evap
+
+        liquid = canopy_evap + soil_evap
+        latent, sensible, ground = partition_energy(rn, tas, liquid, sublimation, dt_days)
+
+        rows.append({
+            "time": step["time"],
+            "pr": pr_rate,
+            "evspsbl": (liquid + sublimation) / dt_days,
+            "mrro": (surface + baseflow) / dt_days,
+            "hfls": latent,
+            "hfss": sensible,
+            "hfg": ground,
+            "mrso": soil,
+            "snw": swe,
+            "canopy": canopy,
+            # No routing: runoff leaves the stores and the catchment in the
+            # same step, so the water in transit is identically zero.
+            # Reported rather than omitted, because it is a statement.
+            "channel": 0.0,
+        })
+    return rows
+
+
+def read_request(path: Path) -> tuple[dict, Path]:
+    request = json.loads(path.read_text())
+    return request, path.parent
+
+
+def read_forcing(path: Path) -> list[dict]:
+    with open(path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    for row in rows:
+        for key in ("pr", "tas", "pet", "rn"):
+            if key in row:
+                row[key] = float(row[key])
+    return rows
+
+
+def write_result(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True)
+    args = parser.parse_args()
+
+    request_path = Path(args.request).resolve()
+    request, io_dir = read_request(request_path)
+    forcing = read_forcing(io_dir / request["input"]["forcing"])
+    static = json.loads((io_dir / request["input"]["static"]).read_text())
+
+    timestep = request.get("timestep", "PT1D")
+    if timestep not in TIMESTEP_DAYS:
+        raise SystemExit(f"unsupported timestep {timestep!r}")
+    rows = simulate(forcing, static, TIMESTEP_DAYS[timestep])
+
+    write_result(io_dir / request["output"]["table"], rows)
+    (io_dir / request["output"]["run"]).write_text(
+        json.dumps({"status": "ok", "model": MODEL, "n_steps": len(rows)}, indent=2)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/reference_energy_leak/ht_adapter.py
+++ b/models/reference_energy_leak/ht_adapter.py
@@ -17,7 +17,7 @@ MODE = "energy_leak"
 MODEL = {"name": "reference_energy_leak", "version": "1.0.0"}
 
 COLUMNS = [
-    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "time", "pr", "evspsbl", "mrro", "sbl", "hfls", "hfss", "hfg",
     "mrso", "snw", "canopy", "channel",
 ]
 
@@ -137,6 +137,9 @@ def simulate(forcing, static, dt_days=1.0):
             "time": step["time"],
             "pr": pr_rate,
             "evspsbl": (liquid + sublimation) / dt_days,
+            # The sublimating share of the evaporation above, so a
+            # criterion never has to infer which kilograms left as ice.
+            "sbl": sublimation / dt_days,
             "mrro": (surface + baseflow) / dt_days,
             "hfls": latent,
             "hfss": sensible,

--- a/models/reference_energy_leak/model.yaml
+++ b/models/reference_energy_leak/model.yaml
@@ -1,0 +1,18 @@
+name: reference_energy_leak
+version: "1.0.0"
+description: >
+  The energy-budget counterpart of reference_leaky: coherent between water
+  and energy, but 15 percent of net radiation never appears in any flux it
+  reports. It exists so that energy_closure has something to catch.
+authors: ["HydroTuring maintainers"]
+license: PolyForm-Noncommercial-1.0.0
+runner: subprocess
+entrypoint: ["python3", "ht_adapter.py"]
+timestep: [PT1D]
+emits:
+  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  states: [mrso, snw, canopy, channel]
+needs_forcing: [pr, tas, pet, rn]
+supports:
+  perturbation: true
+resources: {cpu: 1, memory_gb: 1, gpu: false}

--- a/models/reference_energy_leak/model.yaml
+++ b/models/reference_energy_leak/model.yaml
@@ -10,7 +10,7 @@ runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
 timestep: [PT1D]
 emits:
-  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  fluxes: [pr, evspsbl, mrro, sbl, hfls, hfss, hfg]
   states: [mrso, snw, canopy, channel]
 needs_forcing: [pr, tas, pet, rn]
 supports:

--- a/models/reference_sublimation_blind/ht_adapter.py
+++ b/models/reference_sublimation_blind/ht_adapter.py
@@ -17,7 +17,7 @@ MODE = "sublimation_blind"
 MODEL = {"name": "reference_sublimation_blind", "version": "1.0.0"}
 
 COLUMNS = [
-    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "time", "pr", "evspsbl", "mrro", "sbl", "hfls", "hfss", "hfg",
     "mrso", "snw", "canopy", "channel",
 ]
 
@@ -137,6 +137,9 @@ def simulate(forcing, static, dt_days=1.0):
             "time": step["time"],
             "pr": pr_rate,
             "evspsbl": (liquid + sublimation) / dt_days,
+            # The sublimating share of the evaporation above, so a
+            # criterion never has to infer which kilograms left as ice.
+            "sbl": sublimation / dt_days,
             "mrro": (surface + baseflow) / dt_days,
             "hfls": latent,
             "hfss": sensible,

--- a/models/reference_sublimation_blind/ht_adapter.py
+++ b/models/reference_sublimation_blind/ht_adapter.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""HydroTuring adapter. Standard library only, to show that the /io contract
+needs no scientific Python stack and could be written in any language.
+
+Coherent for liquid water, blind to the phase change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+MODE = "sublimation_blind"
+MODEL = {"name": "reference_sublimation_blind", "version": "1.0.0"}
+
+COLUMNS = [
+    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "mrso", "snw", "canopy", "channel",
+]
+
+EVAP_SHAPE = 0.5   # soil moisture at which evaporation reaches its potential rate
+SUBL_SHARE = 0.35  # share of the remaining demand a snowpack can meet
+GROUND_SHARE = 0.10  # share of net radiation conducted into the ground
+
+# Latent heat of vaporisation as A + B*T (T in degC) and of fusion, J kg-1.
+LAMBDA_A, LAMBDA_B = 2.501e6, -2361.0
+LAMBDA_F = 3.337e5
+LAMBDA_CONST = 2.45e6  # the constant a careless model would use
+CLIMATOLOGICAL_EF = 0.65  # evaporative fraction of a model whose heads never meet
+ENERGY_LEAK = 0.15
+SECONDS_PER_DAY = 86400.0
+
+TIMESTEP_DAYS = {
+    "PT1D": 1.0,
+    "PT1H": 1.0 / 24.0,
+    "PT15M": 1.0 / 96.0,
+    "PT5M": 1.0 / 288.0,
+    "PT1M": 1.0 / 1440.0,
+}
+
+
+def partition_energy(rn, tas, liquid_mm, sublimated_mm, dt_days):
+    """Turn the water that left the surface into the energy that carried it.
+
+    `reference_coupled` is exact: every kilogram is converted at the latent
+    heat of the phase change it actually underwent, and the sensible flux is
+    what net radiation has left once the latent and ground fluxes are taken.
+    Solving for H that way is the physical statement that the surface has no
+    other place to put the energy, and it is why this model closes the energy
+    budget by construction, exactly as `reference_bucket` closes the water
+    budget by construction. The discrimination lives in the other four.
+    """
+    seconds = dt_days * SECONDS_PER_DAY
+    lam_v = LAMBDA_A + LAMBDA_B * tas
+    lam_s = LAMBDA_A + LAMBDA_F
+    ground = GROUND_SHARE * rn
+
+    if MODE == "constant_lambda":
+        latent = LAMBDA_CONST * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "sublimation_blind":
+        latent = lam_v * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "two_head":
+        # An energy head that never reads the water head: the partition is a
+        # climatological evaporative fraction of the available energy, and it
+        # has no idea how much water actually left.
+        latent = CLIMATOLOGICAL_EF * (rn - ground)
+    else:
+        latent = (lam_v * liquid_mm + lam_s * sublimated_mm) / seconds
+
+    sensible = rn - ground - latent
+    if MODE == "energy_leak":
+        sensible -= ENERGY_LEAK * rn
+    return latent, sensible, ground
+
+
+def simulate(forcing, static, dt_days=1.0):
+    """The reference bucket, with snow sublimation and a surface energy budget.
+
+    The water side is `reference_bucket` plus one term: a snowpack meets part
+    of the evaporative demand by sublimating, which is removed from the pack
+    like every other flux, so the water budget still closes to floating point.
+    That term exists because without it no step in the record has a phase
+    change to be coherent about.
+    """
+    soil_cap = static["soil_capacity_mm"]
+    canopy_cap = static["canopy_capacity_mm"]
+    ddf = static["degree_day_factor_mm_per_C_day"]
+    k_base = static["baseflow_coefficient"]
+    t_snow = static["snow_threshold_degC"]
+
+    soil = 0.5 * soil_cap
+    swe = 0.0
+    canopy = 0.0
+    rows = []
+
+    for step in forcing:
+        pr_rate, tas, pet_rate = step["pr"], step["tas"], step["pet"]
+        rn = step.get("rn", 0.0)
+        pr = pr_rate * dt_days
+        pet = pet_rate * dt_days
+
+        snowfall = pr if tas < t_snow else 0.0
+        rain = 0.0 if tas < t_snow else pr
+
+        swe += snowfall
+        melt = min(swe, ddf * max(tas - t_snow, 0.0) * dt_days)
+        swe -= melt
+
+        water_in = rain + melt
+        intercepted = min(canopy_cap - canopy, water_in)
+        canopy += intercepted
+        throughfall = water_in - intercepted
+
+        canopy_evap = min(canopy, pet)
+        canopy -= canopy_evap
+        pet_left = pet - canopy_evap
+
+        sublimation = min(swe, SUBL_SHARE * pet_left) if swe > 0.0 else 0.0
+        swe -= sublimation
+        pet_left -= sublimation
+
+        soil += throughfall
+        surface = max(0.0, soil - soil_cap)
+        soil -= surface
+        baseflow = k_base * soil * dt_days
+        soil -= baseflow
+        soil_evap = min(soil, pet_left * min(1.0, soil / (EVAP_SHAPE * soil_cap)))
+        soil -= soil_evap
+
+        liquid = canopy_evap + soil_evap
+        latent, sensible, ground = partition_energy(rn, tas, liquid, sublimation, dt_days)
+
+        rows.append({
+            "time": step["time"],
+            "pr": pr_rate,
+            "evspsbl": (liquid + sublimation) / dt_days,
+            "mrro": (surface + baseflow) / dt_days,
+            "hfls": latent,
+            "hfss": sensible,
+            "hfg": ground,
+            "mrso": soil,
+            "snw": swe,
+            "canopy": canopy,
+            # No routing: runoff leaves the stores and the catchment in the
+            # same step, so the water in transit is identically zero.
+            # Reported rather than omitted, because it is a statement.
+            "channel": 0.0,
+        })
+    return rows
+
+
+def read_request(path: Path) -> tuple[dict, Path]:
+    request = json.loads(path.read_text())
+    return request, path.parent
+
+
+def read_forcing(path: Path) -> list[dict]:
+    with open(path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    for row in rows:
+        for key in ("pr", "tas", "pet", "rn"):
+            if key in row:
+                row[key] = float(row[key])
+    return rows
+
+
+def write_result(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True)
+    args = parser.parse_args()
+
+    request_path = Path(args.request).resolve()
+    request, io_dir = read_request(request_path)
+    forcing = read_forcing(io_dir / request["input"]["forcing"])
+    static = json.loads((io_dir / request["input"]["static"]).read_text())
+
+    timestep = request.get("timestep", "PT1D")
+    if timestep not in TIMESTEP_DAYS:
+        raise SystemExit(f"unsupported timestep {timestep!r}")
+    rows = simulate(forcing, static, TIMESTEP_DAYS[timestep])
+
+    write_result(io_dir / request["output"]["table"], rows)
+    (io_dir / request["output"]["run"]).write_text(
+        json.dumps({"status": "ok", "model": MODEL, "n_steps": len(rows)}, indent=2)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/reference_sublimation_blind/model.yaml
+++ b/models/reference_sublimation_blind/model.yaml
@@ -11,7 +11,7 @@ runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
 timestep: [PT1D]
 emits:
-  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  fluxes: [pr, evspsbl, mrro, sbl, hfls, hfss, hfg]
   states: [mrso, snw, canopy, channel]
 needs_forcing: [pr, tas, pet, rn]
 supports:

--- a/models/reference_sublimation_blind/model.yaml
+++ b/models/reference_sublimation_blind/model.yaml
@@ -1,0 +1,19 @@
+name: reference_sublimation_blind
+version: "1.0.0"
+description: >
+  Fully coupled with a temperature-dependent latent heat, but it converts
+  snow sublimation at the latent heat of vaporisation instead of sublimation.
+  It is short by 13.3 percent on exactly the steps where a snowpack is
+  losing mass to the atmosphere, and correct everywhere else.
+authors: ["HydroTuring maintainers"]
+license: PolyForm-Noncommercial-1.0.0
+runner: subprocess
+entrypoint: ["python3", "ht_adapter.py"]
+timestep: [PT1D]
+emits:
+  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  states: [mrso, snw, canopy, channel]
+needs_forcing: [pr, tas, pet, rn]
+supports:
+  perturbation: true
+resources: {cpu: 1, memory_gb: 1, gpu: false}

--- a/models/reference_two_head/ht_adapter.py
+++ b/models/reference_two_head/ht_adapter.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""HydroTuring adapter. Standard library only, to show that the /io contract
+needs no scientific Python stack and could be written in any language.
+
+Closes both budgets separately and is incoherent between them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+MODE = "two_head"
+MODEL = {"name": "reference_two_head", "version": "1.0.0"}
+
+COLUMNS = [
+    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "mrso", "snw", "canopy", "channel",
+]
+
+EVAP_SHAPE = 0.5   # soil moisture at which evaporation reaches its potential rate
+SUBL_SHARE = 0.35  # share of the remaining demand a snowpack can meet
+GROUND_SHARE = 0.10  # share of net radiation conducted into the ground
+
+# Latent heat of vaporisation as A + B*T (T in degC) and of fusion, J kg-1.
+LAMBDA_A, LAMBDA_B = 2.501e6, -2361.0
+LAMBDA_F = 3.337e5
+LAMBDA_CONST = 2.45e6  # the constant a careless model would use
+CLIMATOLOGICAL_EF = 0.65  # evaporative fraction of a model whose heads never meet
+ENERGY_LEAK = 0.15
+SECONDS_PER_DAY = 86400.0
+
+TIMESTEP_DAYS = {
+    "PT1D": 1.0,
+    "PT1H": 1.0 / 24.0,
+    "PT15M": 1.0 / 96.0,
+    "PT5M": 1.0 / 288.0,
+    "PT1M": 1.0 / 1440.0,
+}
+
+
+def partition_energy(rn, tas, liquid_mm, sublimated_mm, dt_days):
+    """Turn the water that left the surface into the energy that carried it.
+
+    `reference_coupled` is exact: every kilogram is converted at the latent
+    heat of the phase change it actually underwent, and the sensible flux is
+    what net radiation has left once the latent and ground fluxes are taken.
+    Solving for H that way is the physical statement that the surface has no
+    other place to put the energy, and it is why this model closes the energy
+    budget by construction, exactly as `reference_bucket` closes the water
+    budget by construction. The discrimination lives in the other four.
+    """
+    seconds = dt_days * SECONDS_PER_DAY
+    lam_v = LAMBDA_A + LAMBDA_B * tas
+    lam_s = LAMBDA_A + LAMBDA_F
+    ground = GROUND_SHARE * rn
+
+    if MODE == "constant_lambda":
+        latent = LAMBDA_CONST * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "sublimation_blind":
+        latent = lam_v * (liquid_mm + sublimated_mm) / seconds
+    elif MODE == "two_head":
+        # An energy head that never reads the water head: the partition is a
+        # climatological evaporative fraction of the available energy, and it
+        # has no idea how much water actually left.
+        latent = CLIMATOLOGICAL_EF * (rn - ground)
+    else:
+        latent = (lam_v * liquid_mm + lam_s * sublimated_mm) / seconds
+
+    sensible = rn - ground - latent
+    if MODE == "energy_leak":
+        sensible -= ENERGY_LEAK * rn
+    return latent, sensible, ground
+
+
+def simulate(forcing, static, dt_days=1.0):
+    """The reference bucket, with snow sublimation and a surface energy budget.
+
+    The water side is `reference_bucket` plus one term: a snowpack meets part
+    of the evaporative demand by sublimating, which is removed from the pack
+    like every other flux, so the water budget still closes to floating point.
+    That term exists because without it no step in the record has a phase
+    change to be coherent about.
+    """
+    soil_cap = static["soil_capacity_mm"]
+    canopy_cap = static["canopy_capacity_mm"]
+    ddf = static["degree_day_factor_mm_per_C_day"]
+    k_base = static["baseflow_coefficient"]
+    t_snow = static["snow_threshold_degC"]
+
+    soil = 0.5 * soil_cap
+    swe = 0.0
+    canopy = 0.0
+    rows = []
+
+    for step in forcing:
+        pr_rate, tas, pet_rate = step["pr"], step["tas"], step["pet"]
+        rn = step.get("rn", 0.0)
+        pr = pr_rate * dt_days
+        pet = pet_rate * dt_days
+
+        snowfall = pr if tas < t_snow else 0.0
+        rain = 0.0 if tas < t_snow else pr
+
+        swe += snowfall
+        melt = min(swe, ddf * max(tas - t_snow, 0.0) * dt_days)
+        swe -= melt
+
+        water_in = rain + melt
+        intercepted = min(canopy_cap - canopy, water_in)
+        canopy += intercepted
+        throughfall = water_in - intercepted
+
+        canopy_evap = min(canopy, pet)
+        canopy -= canopy_evap
+        pet_left = pet - canopy_evap
+
+        sublimation = min(swe, SUBL_SHARE * pet_left) if swe > 0.0 else 0.0
+        swe -= sublimation
+        pet_left -= sublimation
+
+        soil += throughfall
+        surface = max(0.0, soil - soil_cap)
+        soil -= surface
+        baseflow = k_base * soil * dt_days
+        soil -= baseflow
+        soil_evap = min(soil, pet_left * min(1.0, soil / (EVAP_SHAPE * soil_cap)))
+        soil -= soil_evap
+
+        liquid = canopy_evap + soil_evap
+        latent, sensible, ground = partition_energy(rn, tas, liquid, sublimation, dt_days)
+
+        rows.append({
+            "time": step["time"],
+            "pr": pr_rate,
+            "evspsbl": (liquid + sublimation) / dt_days,
+            "mrro": (surface + baseflow) / dt_days,
+            "hfls": latent,
+            "hfss": sensible,
+            "hfg": ground,
+            "mrso": soil,
+            "snw": swe,
+            "canopy": canopy,
+            # No routing: runoff leaves the stores and the catchment in the
+            # same step, so the water in transit is identically zero.
+            # Reported rather than omitted, because it is a statement.
+            "channel": 0.0,
+        })
+    return rows
+
+
+def read_request(path: Path) -> tuple[dict, Path]:
+    request = json.loads(path.read_text())
+    return request, path.parent
+
+
+def read_forcing(path: Path) -> list[dict]:
+    with open(path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    for row in rows:
+        for key in ("pr", "tas", "pet", "rn"):
+            if key in row:
+                row[key] = float(row[key])
+    return rows
+
+
+def write_result(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True)
+    args = parser.parse_args()
+
+    request_path = Path(args.request).resolve()
+    request, io_dir = read_request(request_path)
+    forcing = read_forcing(io_dir / request["input"]["forcing"])
+    static = json.loads((io_dir / request["input"]["static"]).read_text())
+
+    timestep = request.get("timestep", "PT1D")
+    if timestep not in TIMESTEP_DAYS:
+        raise SystemExit(f"unsupported timestep {timestep!r}")
+    rows = simulate(forcing, static, TIMESTEP_DAYS[timestep])
+
+    write_result(io_dir / request["output"]["table"], rows)
+    (io_dir / request["output"]["run"]).write_text(
+        json.dumps({"status": "ok", "model": MODEL, "n_steps": len(rows)}, indent=2)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/reference_two_head/ht_adapter.py
+++ b/models/reference_two_head/ht_adapter.py
@@ -17,7 +17,7 @@ MODE = "two_head"
 MODEL = {"name": "reference_two_head", "version": "1.0.0"}
 
 COLUMNS = [
-    "time", "pr", "evspsbl", "mrro", "hfls", "hfss", "hfg",
+    "time", "pr", "evspsbl", "mrro", "sbl", "hfls", "hfss", "hfg",
     "mrso", "snw", "canopy", "channel",
 ]
 
@@ -137,6 +137,9 @@ def simulate(forcing, static, dt_days=1.0):
             "time": step["time"],
             "pr": pr_rate,
             "evspsbl": (liquid + sublimation) / dt_days,
+            # The sublimating share of the evaporation above, so a
+            # criterion never has to infer which kilograms left as ice.
+            "sbl": sublimation / dt_days,
             "mrro": (surface + baseflow) / dt_days,
             "hfls": latent,
             "hfss": sensible,

--- a/models/reference_two_head/model.yaml
+++ b/models/reference_two_head/model.yaml
@@ -12,7 +12,7 @@ runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
 timestep: [PT1D]
 emits:
-  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  fluxes: [pr, evspsbl, mrro, sbl, hfls, hfss, hfg]
   states: [mrso, snw, canopy, channel]
 needs_forcing: [pr, tas, pet, rn]
 supports:

--- a/models/reference_two_head/model.yaml
+++ b/models/reference_two_head/model.yaml
@@ -1,0 +1,20 @@
+name: reference_two_head
+version: "1.0.0"
+description: >
+  The honest caricature of a model with a water head and an energy head that
+  never have to agree. The water side is exactly reference_coupled. The
+  energy side partitions net radiation by a fixed climatological evaporative
+  fraction and never reads the soil. Both budgets close to floating point;
+  the latent heat it reports implies an evaporation it never reported.
+authors: ["HydroTuring maintainers"]
+license: PolyForm-Noncommercial-1.0.0
+runner: subprocess
+entrypoint: ["python3", "ht_adapter.py"]
+timestep: [PT1D]
+emits:
+  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  states: [mrso, snw, canopy, channel]
+needs_forcing: [pr, tas, pet, rn]
+supports:
+  perturbation: true
+resources: {cpu: 1, memory_gb: 1, gpu: false}

--- a/probes/energy/latent-heat-et-consistency/README.md
+++ b/probes/energy/latent-heat-et-consistency/README.md
@@ -1,0 +1,155 @@
+# energy/latent-heat-et-consistency
+
+Ten years of generated daily weather and net radiation over a lumped
+catchment. The question is not whether either budget closes. It is whether the
+evaporation the model reports as water and the evaporation implied by the
+latent heat flux it reports are the same evaporation.
+
+```
+LE = lambda(T, phase) * E
+```
+
+This is the first probe in the suite that no single-budget criterion can
+substitute for. A model with a water head and an energy head can close the
+water budget to floating point, close the energy budget to floating point, and
+still be reporting two different evaporations, because the contradiction lives
+strictly between the ledgers. `reference_two_head` is that model, and it is
+what this probe exists to catch.
+
+## Why the tolerance is not five percent
+
+The suite's engineering rule is five percent of the driving flux. It is the
+right rule for a budget and the wrong rule here, for a reason that is
+arithmetic rather than a matter of taste.
+
+`lambda_v(T) = 2.501e6 - 2361 T` J kg-1. Over a -20 to +35 degC record a model
+that uses a constant instead is wrong by at most **3.4 percent**. Five percent
+cannot see it. `flux_identity` is therefore scored at every step against
+**0.5 percent** of the reported flux, with an absolute floor because the flux
+passes through zero and a percentage of nothing is not a bound.
+
+The floor is **0.5 W m-2**, not the 2 W m-2 that a first reading of the
+nighttime problem suggests. At 2 W m-2 a constant-lambda model survives every
+step whose evaporation is below roughly 3.5 mm/day, which on this record is
+most of them: it trips 4 steps of 3650 rather than 33, and a different seed
+could let it through entirely. That number came from running it.
+
+Two remarks for anyone tempted to argue the tolerance is too tight. First, no
+observation enters this probe: the reference budget is exact by construction
+and the criterion measures a model against itself, so observational
+uncertainty is not what is being bounded. Second, 0.5 percent is one to two
+orders of magnitude below the spread between published ET products, which is
+routinely 10 to 30 percent at annual scale. That gap is the point.
+
+### The obvious objection, and why it argues the other way
+
+*Observed surface energy budgets do not close. How can a benchmark demand
+half a percent?*
+
+They do not, and the size of the gap is well documented: energy balance
+closure at eddy covariance sites varies systematically in space and time (Cui
+& Chui 2019), and a recent correction across 172 flux towers moves the mean
+imbalance from -14.99 to -0.65 W m-2 (Zhang et al. 2024) — that is, the raw
+imbalance is of the order of 15 W m-2, roughly thirty times this probe's
+floor.
+
+That is precisely why the test belongs on the synthetic track and measures a
+model against itself. If an observed budget were the reference, no tolerance
+would be defensible, because the reference would be the thing that does not
+close. ROADMAP already says this about the real-data track: "observed budgets
+do not close, so observations can never be the reference". This probe is the
+same argument applied to the energy budget, and it is the reason
+`flux_identity` should never be ported to that track.
+
+## The phase change, and what is not assumed
+
+Water leaving a snowpack sublimates and takes `lambda_s = lambda_v(0) +
+lambda_f`, **13.3 percent** more energy per kilogram. A model that converts
+every kilogram at the vaporisation rate is short of that on exactly the steps
+where a pack is losing mass to the atmosphere.
+
+The sublimated mass is never assumed. Each step falls into one of three cases,
+decided from the forcing and the model's own snow state:
+
+| Case | What is asserted |
+| --- | --- |
+| No pack, and none can fall during the step | `LE = lambda_v(T) E` |
+| Pack, no precipitation, air below freezing: nothing can fall and nothing can melt, so the pack's own reported mass loss is the sublimated mass | `LE = lambda_v L + lambda_s S` |
+| Pack, anything else: melt and sublimation are not separable from what the model reports | `lambda_v(T) E <= LE <= lambda_s E` |
+
+The third case is deliberately weak. Asserting a split the model never
+reported would fail an honest model whose snow physics differs from the
+reference's, and a criterion that does that is worse than no criterion. The
+discrimination survives it: `reference_sublimation_blind` is caught on the
+second case, which this record supplies about 400 steps of per seed.
+
+A model that reports no snow state simply has the split disabled rather than
+being judged against an assumption about it.
+
+## The case
+
+`generate.py`, from a recorded seed, ten years plus a year of spinup. The
+water side is the record of `mass/catchment-closure`, unchanged, so a model
+already adapted to that probe sees nothing unfamiliar. Two things are added.
+
+Net radiation comes from a clear-sky cycle at 40 degN, attenuated by its own
+AR(1) cloudiness process, with an albedo that switches below freezing and an
+outgoing longwave term that follows air temperature. It crosses zero on winter
+days, which is why the energy criteria carry a floor.
+
+Potential evapotranspiration is then derived from that net radiation by
+Priestley-Taylor with alpha = 1.26, rather than being an independent function
+of temperature. A reviewer will ask why the demand and the available energy in
+a coherence probe are consistent with one another, and this is the answer:
+they are not two forcings, they are one. The consequence that matters is that
+PET stays small but non-zero on cold clear days, without which no snowpack
+would ever sublimate and half the criterion would have nothing to score.
+
+Typical record: about 800 mm/yr of precipitation, 550 mm/yr of potential ET,
+net radiation averaging 79 W m-2, and roughly 550 dry sub-zero days in 4015.
+
+## Related work
+
+Enforcing conservation inside a neural emulator, and quantifying the "physical
+inconsistency" left when it is not enforced, is established for atmospheric
+convection: Beucler et al. (2021) constrain neural networks emulating
+convective processes either architecturally or through the loss, and measure
+the violation across mass, momentum, radiation and energy budgets. That is the
+nearest prior art to this probe and it should be read first.
+
+Three things here are different. The verdict is binary rather than a penalty
+term, because a benchmark has to be able to reject. The budgets are the
+surface water and energy budgets of a catchment rather than a convective
+column. And the sibling probe, `energy/evaporative-partition`, asserts a
+cross-budget response to a counterfactual rather than a same-instant residual,
+which is a property no amount of accuracy on either run establishes.
+
+## What each reference model does here
+
+| Model | Both budgets close? | Verdict |
+| --- | --- | --- |
+| `reference_coupled` | yes | PASS, every criterion |
+| `reference_two_head` | yes, to 1e-15 | `flux_identity`, 3495 steps of 3650, implied lambda 3.13e6 J kg-1 |
+| `reference_constant_lambda` | yes | `flux_identity` |
+| `reference_sublimation_blind` | yes | `flux_identity`, sublimating steps only |
+| `reference_energy_leak` | water only | `energy_closure` |
+| `reference_bucket` | water only | INCOMPLETE: reports no energy fluxes |
+
+That last row is the suite-level consequence of the first energy probe, and it
+is the correct verdict rather than a regression. A water-only model has not
+violated conservation of energy; it has declined to be falsifiable about it,
+which is what INCOMPLETE has always meant here.
+
+## References
+
+- Beucler, T., Pritchard, M., Rasp, S., Ott, J., Baldi, P., & Gentine, P. (2021).
+  Enforcing analytic constraints in neural networks emulating physical systems.
+  *Physical Review Letters*, 126, 098302. https://doi.org/10.1103/PhysRevLett.126.098302
+- Cui, W., & Chui, T. F. M. (2019). Temporal and spatial variations of energy balance
+  closure across FLUXNET research sites. *Agricultural and Forest Meteorology*, 271, 12-21.
+  https://doi.org/10.1016/j.agrformet.2019.02.026
+- Zhang, W., Nelson, J. A., Miralles, D. G., Mauder, M., Migliavacca, M., Poyatos, R.,
+  Reichstein, M., & Jung, M. (2024). A new post-hoc method to reduce the energy imbalance
+  in eddy covariance measurements. *Geophysical Research Letters*, 51(2), e2023GL107084.
+  https://doi.org/10.1029/2023GL107084
+- Brutsaert, W. (1982). *Evaporation into the Atmosphere*. Reidel.

--- a/probes/energy/latent-heat-et-consistency/README.md
+++ b/probes/energy/latent-heat-et-consistency/README.md
@@ -61,30 +61,107 @@ do not close, so observations can never be the reference". This probe is the
 same argument applied to the energy budget, and it is the reason
 `flux_identity` should never be ported to that track.
 
-## The phase change, and what is not assumed
+## The phase change, and why the criterion asks instead of guessing
 
 Water leaving a snowpack sublimates and takes `lambda_s = lambda_v(0) +
 lambda_f`, **13.3 percent** more energy per kilogram. A model that converts
 every kilogram at the vaporisation rate is short of that on exactly the steps
 where a pack is losing mass to the atmosphere.
 
-The sublimated mass is never assumed. Each step falls into one of three cases,
-decided from the forcing and the model's own snow state:
+Knowing which kilograms those were is the whole difficulty, and the first
+version of this criterion got it wrong. It inferred the split: on a step with
+no precipitation and air below freezing, nothing can fall and nothing can
+melt, so any decrease in the reported snow store must be sublimation. That
+reasoning has a hole. **A pack also loses water at its base.** Snow-17's
+`DAYGM` term is exactly that, and this repository's own `sacsma_snow17` port
+runs it at 0.1 mm/day.
 
-| Case | What is asserted |
+Review reproduced the consequence. Taking `reference_coupled` unchanged except
+for a constant ground melt into the soil, with the latent heat still exactly
+right:
+
+| Honest model | old criterion |
 | --- | --- |
-| No pack, and none can fall during the step | `LE = lambda_v(T) E` |
-| Pack, no precipitation, air below freezing: nothing can fall and nothing can melt, so the pack's own reported mass loss is the sublimated mass | `LE = lambda_v L + lambda_s S` |
-| Pack, anything else: melt and sublimation are not separable from what the model reports | `lambda_v(T) E <= LE <= lambda_s E` |
+| no ground melt | pass, worst 0.00 of tolerance |
+| ground melt 0.1 mm/day (this repository's Snow-17 setting) | pass, worst 0.77 |
+| ground melt 0.3 mm/day | **fail on 375 to 429 steps of 3650**, worst 2.32 |
 
-The third case is deliberately weak. Asserting a split the model never
-reported would fail an honest model whose snow physics differs from the
-reference's, and a criterion that does that is worse than no criterion. The
-discrimination survives it: `reference_sublimation_blind` is caught on the
-second case, which this record supplies about 400 steps of per seed.
+The probe's own stated principle is that a criterion which fails an honest
+model whose snow physics differs from the reference's is worse than no
+criterion. The inference did exactly that, with 23 percent of the tolerance to
+spare at the repository's own default. So the criterion no longer infers.
 
-A model that reports no snow state simply has the split disabled rather than
-being judged against an assumption about it.
+**A model that reports `sbl`** — the sublimating share of its evaporation, a
+component of `evspsbl` and never an addition to it — is held to the equality
+at every step, pack or no pack, because it has said which kilograms left as
+ice:
+
+```
+LE = lambda_v(T) * (E - sbl) + lambda_s * sbl
+```
+
+The claim has to be a real one: `sbl` may not be negative, may not exceed the
+evaporation it is a share of, and must be zero where the model itself reports
+no snow and none could fall. Without that last condition a warm-season model
+could report a fictitious sublimating share to bend its effective lambda
+upwards.
+
+**A model that does not report `sbl`** is held to the equality at `lambda_v`
+on steps where it reports no pack and none could arrive, and to the interval
+
+```
+lambda_v(T) * E  <=  LE  <=  lambda_s * E
+```
+
+wherever a pack is or could be present. Nothing is guessed.
+
+The same ground-melt model under the criterion as it now stands, in both
+postures:
+
+| Ground melt | reports `sbl` | declines to report |
+| --- | --- | --- |
+| 0.0 mm/day | pass, worst 0.00 | pass |
+| 0.1 mm/day | pass, worst 0.00 | pass |
+| 0.3 mm/day | pass, worst 0.00 | pass |
+| 1.0 mm/day | pass, worst 0.00 | pass |
+
+**What this costs.** A model that declines to report `sbl` cannot be caught on
+the phase change at all; the interval is wide enough to admit a
+sublimation-blind model exactly on its lower bound. That is the honest price
+of not guessing, and it is the right price: without the model saying which
+kilograms were ice, blindness and a draining pack base are indistinguishable
+from the outside. `reference_sublimation_blind` reports `sbl` and is caught on
+every sublimating step rather than only the dry frozen ones, so the
+discrimination is stronger where the information exists and absent where it
+does not.
+
+## A choice the benchmark is making, stated plainly
+
+`flux_identity` at 0.5 percent fails any model that uses a **constant** latent
+heat of vaporisation, and `reference_constant_lambda` exists to make sure it
+does. That is a position, not a conservation law, and it should be argued with
+rather than discovered.
+
+A constant lambda is a common convention in land-surface schemes, and a model
+using one is internally consistent: its water and its energy describe the same
+evaporation, at a lambda that is wrong by at most 3.4 percent over this
+record. What the criterion asserts is a specific thermodynamic
+parameterisation, `lambda_v(T) = 2.501e6 - 2361 T`, not merely that the two
+budgets agree.
+
+The benchmark chooses to call the constant a violation, for two reasons. The
+identity is thermodynamics rather than a modelling choice, and 3.4 percent is
+two orders of magnitude above what an exact model achieves here. And a
+tolerance loose enough to admit a constant lambda is loose enough to admit a
+model whose lambda is not a lambda at all, which is the failure the probe
+exists for.
+
+If the maintainers would rather this probe test coherence alone and leave the
+temperature dependence to a separate criterion, the change is one parameter:
+`lambda_vapour: [2.45e6, 0.0]` with `rel_tol` raised to the suite's 5 percent
+turns it into that probe, and `reference_constant_lambda` would then belong to
+the criterion that replaces it. This is worth settling before an LSM group
+meets it in a report rather than after.
 
 ## The case
 
@@ -134,11 +211,22 @@ which is a property no amount of accuracy on either run establishes.
 | `reference_sublimation_blind` | yes | `flux_identity`, sublimating steps only |
 | `reference_energy_leak` | water only | `energy_closure` |
 | `reference_bucket` | water only | INCOMPLETE: reports no energy fluxes |
+| `flex_lumped`, `flex_topo`, `sacsma_snow17` | water only | INCOMPLETE, the same way |
 
-That last row is the suite-level consequence of the first energy probe, and it
-is the correct verdict rather than a regression. A water-only model has not
-violated conservation of energy; it has declined to be falsifiable about it,
-which is what INCOMPLETE has always meant here.
+Those last two rows are the suite-level consequence of the first probe that
+needs energy fluxes, and they are the correct verdict rather than a
+regression. A water-only model has not violated conservation of energy; it has
+declined to be falsifiable about it, which is what INCOMPLETE has always meant
+here. It is why `must_pass` names `reference_coupled` alone: every
+hand-written physical model in the suite returns INCOMPLETE on this probe, so
+none of them can guard its tolerance.
+
+`min_window_days` is 3650 for the same family of reasons. A submitted model is
+otherwise scored on a 30-day flood window, and on thirty days of this record
+runoff is nearly constant, `non_degenerate` trips on the exact model, and the
+phase change supplies three sublimating steps instead of about eight hundred.
+The expectations here hold over the record, so the record is what a model is
+judged on.
 
 ## References
 

--- a/probes/energy/latent-heat-et-consistency/generate.py
+++ b/probes/energy/latent-heat-et-consistency/generate.py
@@ -1,0 +1,125 @@
+"""Seeded synthetic forcing for the latent-heat / ET coherence probe.
+
+Deterministic given a seed, and never committed as data. Generating the case
+at run time is what stops a model from memorising it, and shipping the
+generator instead of a NetCDF file is what lets a reviewer see exactly what
+the model will be given.
+
+The water side is the record of `mass/catchment-closure`: the same occurrence
+and depth process for precipitation, the same annual cycle and AR(1) anomaly
+for temperature, so that a model already adapted to that probe sees nothing
+unfamiliar. Two things are added.
+
+Net radiation is generated from a clear-sky cycle at the catchment's latitude,
+attenuated by a seeded cloudiness process, with an albedo that switches when
+the air is below freezing and an outgoing longwave term that follows air
+temperature. It changes sign on winter days, which is deliberate: it is what
+forces the energy criteria to carry an absolute floor rather than a bare
+percentage.
+
+Potential evapotranspiration is then derived from that net radiation by the
+Priestley-Taylor equation with alpha = 1.26, rather than being an independent
+temperature function. A reviewer will ask why the demand and the available
+energy in a coherence probe are consistent with each other, and this is the
+answer: they are not two forcings, they are one.
+
+The consequence that matters for the probe is that PET stays small but
+non-zero on cold, clear days. Without it no snowpack would ever sublimate,
+and the phase-change half of the criterion would have nothing to score.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+PERIOD_YEARS = 10
+SPINUP_DAYS = 365
+N_STEPS = PERIOD_YEARS * 365 + SPINUP_DAYS
+
+# Priestley-Taylor, and the psychrometric constant at sea level.
+PT_ALPHA = 1.26
+GAMMA_KPA_PER_C = 0.0665
+GROUND_SHARE = 0.10
+
+STATIC = {
+    "area_km2": 250.0,
+    "soil_capacity_mm": 320.0,
+    "canopy_capacity_mm": 2.0,
+    "degree_day_factor_mm_per_C_day": 3.2,
+    "baseflow_coefficient": 0.006,
+    "snow_threshold_degC": 0.0,
+    "latitude_deg": 40.0,
+}
+
+
+def _saturation_slope(tas: np.ndarray) -> np.ndarray:
+    """d(e_s)/dT in kPa per degC, the Tetens form used everywhere."""
+    es = 0.6108 * np.exp(17.27 * tas / (tas + 237.3))
+    return 4098.0 * es / np.square(tas + 237.3)
+
+
+def generate(seed: int) -> tuple[pd.DataFrame, dict]:
+    rng = np.random.default_rng(seed)
+    day = np.arange(N_STEPS)
+    doy = day % 365
+
+    # Precipitation: seasonal occurrence, gamma depths on wet days.
+    p_wet = 0.25 + 0.12 * np.cos(2 * np.pi * (doy - 30) / 365)
+    wet = rng.random(N_STEPS) < p_wet
+    depth = rng.gamma(shape=0.7, scale=13.0, size=N_STEPS)
+    pr = np.where(wet, depth, 0.0)
+
+    # Temperature: annual cycle plus a persistent (AR1) weather anomaly.
+    seasonal = 9.0 - 12.0 * np.cos(2 * np.pi * (doy - 15) / 365)
+    noise = np.zeros(N_STEPS)
+    innovation = rng.normal(0.0, 2.6, N_STEPS)
+    for t in range(1, N_STEPS):
+        noise[t] = 0.72 * noise[t - 1] + innovation[t]
+    tas = seasonal + noise
+
+    # Cloudiness: its own AR(1), so that a bright winter day and a dull summer
+    # one both occur and net radiation is not a pure function of the calendar.
+    cloud = np.zeros(N_STEPS)
+    shock = rng.normal(0.0, 0.45, N_STEPS)
+    for t in range(1, N_STEPS):
+        cloud[t] = 0.55 * cloud[t - 1] + shock[t]
+    clearness = np.clip(0.72 + 0.18 * cloud, 0.35, 1.0)
+
+    # Daily-mean incoming shortwave at 40 degN, and the surface it lands on.
+    rsds = (245.0 - 135.0 * np.cos(2 * np.pi * (doy - 172) / 365)) * clearness
+    albedo = np.where(tas < STATIC["snow_threshold_degC"], 0.60, 0.23)
+    longwave_out = np.clip(32.0 + 1.2 * tas, 15.0, 95.0) * (0.55 + 0.45 * clearness)
+    rn = (1.0 - albedo) * rsds - longwave_out
+
+    # Priestley-Taylor demand on the available energy.
+    slope = _saturation_slope(tas)
+    lam = 2.501e6 - 2361.0 * tas
+    available = np.maximum(rn * (1.0 - GROUND_SHARE), 0.0)
+    pet = PT_ALPHA * (slope / (slope + GAMMA_KPA_PER_C)) * available * 86400.0 / lam
+
+    time = pd.date_range("2000-01-01", periods=N_STEPS, freq="D")
+    forcing = pd.DataFrame(
+        {
+            "time": time.strftime("%Y-%m-%d"),
+            "pr": np.round(pr, 6),
+            "tas": np.round(tas, 6),
+            "pet": np.round(pet, 6),
+            "rn": np.round(rn, 6),
+        }
+    )
+    return forcing, dict(STATIC)
+
+
+if __name__ == "__main__":
+    frame, static = generate(20260903)
+    years = N_STEPS / 365
+    dry_frozen = ((frame["pr"] == 0) & (frame["tas"] < 0)).sum()
+    print(
+        f"{len(frame)} steps, {frame['pr'].sum() / years:.0f} mm/yr precipitation, "
+        f"{frame['pet'].sum() / years:.0f} mm/yr potential ET, "
+        f"rn mean {frame['rn'].mean():.1f} W/m2 "
+        f"(min {frame['rn'].min():.1f}, max {frame['rn'].max():.1f}), "
+        f"{int((frame['rn'] < 0).sum())} days of negative rn, "
+        f"{int(dry_frozen)} dry sub-zero days"
+    )

--- a/probes/energy/latent-heat-et-consistency/probe.yaml
+++ b/probes/energy/latent-heat-et-consistency/probe.yaml
@@ -1,0 +1,113 @@
+id: energy/latent-heat-et-consistency
+title: Latent heat and evapotranspiration must describe one evaporation
+law: energy
+track: synthetic
+version: 1
+
+authors:
+  - name: Changming Li
+    affiliation: South China University of Technology
+    orcid: 0000-0003-1793-1824
+
+description: >
+  Force a lumped catchment with ten years of generated daily weather and net
+  radiation, and ask whether the evaporation the model reports as water and
+  the evaporation implied by the latent heat flux it reports are the same
+  evaporation. A model with a water head and an energy head can close both
+  budgets independently and still fail this, because the contradiction lives
+  strictly between the budgets and no single-budget criterion can reach it.
+  Both budgets are therefore also scored here: an incoherence claim means
+  nothing unless the two ledgers it spans are each closed.
+
+requires:
+  fluxes: [pr, evspsbl, mrro, hfls, hfss, hfg]
+  states: [mrso, snw, canopy]
+
+case:
+  generator: generate.py
+  n_seeds: 5
+  timestep: PT1D
+  period_years: 10
+  spinup_days: 365
+  max_output_mb: 3.0
+  max_runtime_s: 60
+
+criteria:
+  # The water budget, on the same terms as mass/catchment-closure. The
+  # coherence criterion below is a claim about two closed budgets, so this one
+  # is a precondition rather than the point.
+  - closure:
+      denominator: sum_pr
+      threshold: 0.05
+      sinks: [evspsbl, mrro]
+
+  # The energy budget. hfg is the storage term, so there is no energy state to
+  # difference. Net radiation crosses zero on winter days, hence the floor.
+  - energy_closure:
+      driver: rn
+      sinks: [hfls, hfss, hfg]
+      threshold: 0.05
+      floor: 2.0
+
+  # The cross-budget identity, scored at every step. 0.5 percent rather than
+  # the suite's 5 percent because the failure this exists to catch is only
+  # 3.4 percent large: a constant latent heat of vaporisation is invisible to
+  # the engineering rule. The floor is 0.5 W m-2 rather than 2, because at 2 a
+  # constant-lambda model survives every step whose evaporation is under about
+  # 3.5 mm/day, which is most of them.
+  - flux_identity:
+      flux: hfls
+      water: evspsbl
+      temperature: tas
+      rel_tol: 0.005
+      abs_floor: 0.5
+      lambda_vapour: [2.501e6, -2361.0]
+      lambda_fusion: 3.337e5
+      phase_state: snw
+      snowfall_from: pr
+      snow_threshold_degC: 0.0
+
+  # Catches closure by construction on the water side, as in the mass probe.
+  - state_bounds:
+      mrso: [0.0, soil_capacity_mm]
+      snw: [0.0, null]
+      canopy: [0.0, canopy_capacity_mm]
+
+  # Catches the ET = P escape, which closes the water budget with no runoff.
+  - et_plausible:
+      max_ratio_to_pet: 1.0
+      pet_variable: pet
+
+  # Catches every remaining trivial partition.
+  - non_degenerate:
+      runoff_ratio: [0.02, 0.98]
+      min_flux_cv: 0.1
+      min_response: 0.05
+      cv_variables: [mrro, evspsbl]
+
+  # Stops a model from closing a budget against its own rescaled driver.
+  - forcing_fidelity:
+      variables: [pr]
+      rtol: 1.0e-6
+
+baselines:
+  must_pass: [reference_coupled]
+  must_fail:
+    reference_two_head: flux_identity
+    reference_constant_lambda: flux_identity
+    reference_sublimation_blind: flux_identity
+    reference_energy_leak: energy_closure
+
+citation: >
+  Brutsaert, W. (1982). Evaporation into the Atmosphere. Reidel, for the
+  temperature dependence of the latent heat of vaporisation and for the
+  Priestley-Taylor coefficient the generator uses to derive demand from
+  available energy; Beucler, T., Pritchard, M., Rasp, S., Ott, J., Baldi, P.,
+  and Gentine, P. (2021), Physical Review Letters 126, 098302,
+  doi:10.1103/PhysRevLett.126.098302, as the nearest prior art: the same
+  conservation question for neural emulators, posed as a penalty term rather
+  than as a gate.
+
+provenance: >
+  Synthetic. Generated at run time by generate.py from a recorded seed.
+  Nothing is committed as data, so there is nothing to memorise.

--- a/probes/energy/latent-heat-et-consistency/probe.yaml
+++ b/probes/energy/latent-heat-et-consistency/probe.yaml
@@ -31,6 +31,12 @@ case:
   spinup_days: 365
   max_output_mb: 3.0
   max_runtime_s: 60
+  # A submitted model is otherwise scored on a 30-day flood window, and on
+  # thirty days of this record runoff is nearly constant, the exact model
+  # trips non_degenerate, and the phase change supplies three sublimating
+  # steps instead of four hundred. The expectations here hold over the
+  # record, so the record is what a model is judged on.
+  min_window_days: 3650
 
 criteria:
   # The water budget, on the same terms as mass/catchment-closure. The
@@ -63,6 +69,11 @@ criteria:
       abs_floor: 0.5
       lambda_vapour: [2.501e6, -2361.0]
       lambda_fusion: 3.337e5
+      # Optional. A model that reports its sublimating share is held to the
+      # equality at every step; one that does not is held to the interval the
+      # two latent heats span wherever a pack is or could be present, and is
+      # never failed for a split it did not claim.
+      sublimation: sbl
       phase_state: snw
       snowfall_from: pr
       snow_threshold_degC: 0.0

--- a/src/hydroturing/criteria/__init__.py
+++ b/src/hydroturing/criteria/__init__.py
@@ -15,6 +15,7 @@ from hydroturing.criteria.base import (  # noqa: F401
 from hydroturing.criteria import (  # noqa: F401,E402
     closure,
     bounds,
+    coherence,
     degeneracy,
     limits,
     regime,

--- a/src/hydroturing/criteria/coherence.py
+++ b/src/hydroturing/criteria/coherence.py
@@ -1,0 +1,267 @@
+"""Cross-budget coherence: two budgets that close, describing one evaporation.
+
+A model with a water head and an energy head can close both budgets and still
+report a latent heat flux implying a different evaporation than the one it
+reported as water. No single-budget criterion can see that, because within
+either budget the numbers are consistent. This module holds the criteria that
+compare across the two.
+
+The identity is exact, not a parameterisation:
+
+    LE = lambda * E
+
+with LE in W m-2, E in kg m-2 s-1, and lambda the latent heat of the phase
+change the water actually undergoes. Two things make it discriminating rather
+than arithmetic.
+
+First, lambda depends on temperature. `lambda_v(T) = 2.501e6 - 2361 T` J kg-1
+(Brutsaert 1982), so a model using a constant is wrong by at most 3.4 percent
+over a -20 to +35 degC record. That is invisible to the suite's 5 percent rule,
+which is why this criterion is scored per step against a much tighter bound.
+
+Second, lambda jumps at the phase change. Water leaving a snowpack sublimates
+and takes `lambda_s = lambda_v(0) + lambda_f`, 13.3 percent more energy per
+kilogram. A model that converts every kilogram at the vaporisation rate is
+short of that on exactly the steps where snow is disappearing.
+
+The sublimated mass is not assumed. On a step with no precipitation and air
+below freezing, no snow can fall and none can melt, so any decrease in the
+snow water equivalent the model itself reported is sublimation. Where the
+split cannot be inferred that way, because a pack is present and melting is
+possible, the criterion asserts only the interval that the two latent heats
+span rather than an equality. A criterion that failed an honest model whose
+snow physics differs from the reference's would be worse than no criterion,
+and a model that declines to report a snow state simply has the split
+disabled rather than being judged against an assumption about it.
+
+Related work. Enforcing conservation inside a neural emulator, and measuring
+the "physical inconsistency" left over when it is not enforced, is established
+for atmospheric convection (Beucler, Pritchard, Rasp, Ott, Baldi and Gentine,
+2021, Phys. Rev. Lett. 126, 098302). What is different here is the form and
+the domain: a binary gate rather than a penalty term, over the surface water
+and energy budgets, evaluated as a residual the model cannot fit away.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from hydroturing.criteria.base import FAIL, PASS, CriterionResult, criterion, make_window
+from hydroturing.protocol import RunResult
+from hydroturing.spec import ProbeSpec
+
+# Latent heat of vaporisation as A + B*T, T in degC, J kg-1.
+LAMBDA_V = (2.501e6, -2361.0)
+# Latent heat of fusion, J kg-1. lambda_s = A + LAMBDA_F.
+LAMBDA_F = 3.337e5
+SECONDS_PER_DAY = 86400.0
+
+
+@criterion("flux_identity")
+def flux_identity(run: RunResult, probe: ProbeSpec, params: dict) -> CriterionResult:
+    """Latent heat must equal the reported evaporation times its latent heat.
+
+    Scored at every step. The tolerance is relative to the reported flux with
+    an absolute floor, because the flux passes through zero and a percentage
+    of nothing is not a bound.
+    """
+    flux = str(params.get("flux", "hfls"))
+    water = str(params.get("water", "evspsbl"))
+    temperature = str(params.get("temperature", "tas"))
+    rel_tol = float(params.get("rel_tol", 0.005))
+    abs_floor = float(params.get("abs_floor", 0.5))
+    lam_a, lam_b = (float(v) for v in params.get("lambda_vapour", LAMBDA_V))
+    lam_f = float(params.get("lambda_fusion", LAMBDA_F))
+    phase_state = params.get("phase_state", "snw")
+    snowfall_var = str(params.get("snowfall_from", "pr"))
+    snow_threshold = float(params.get("snow_threshold_degC", 0.0))
+
+    w = make_window(run, probe)
+    for var in (flux, water):
+        if var not in w.table.columns:
+            raise ValueError(f"flux_identity needs '{var}' in the model result")
+    if temperature not in w.forcing.columns:
+        raise ValueError(
+            f"flux_identity needs forcing column '{temperature}'; this probe's "
+            "generator does not produce it"
+        )
+
+    dt = w.dt_days
+    tas = w.forcing[temperature].to_numpy(dtype=float)
+    le = w.table[flux].to_numpy(dtype=float)
+    # mm day-1 is kg m-2 day-1, so a per-step depth is a per-step mass.
+    et_mass = w.table[water].to_numpy(dtype=float) * dt
+
+    lam_v = lam_a + lam_b * tas
+    lam_s = lam_a + lam_f
+    seconds = dt * SECONDS_PER_DAY
+
+    # Every step falls into one of three cases, and only two of them are an
+    # equality. Which case a step is in is decided from the forcing and the
+    # model's own snow state, never from an assumption about how the model
+    # partitions evaporation.
+    #
+    #   no pack           all of it is liquid          LE = lambda_v(T) E
+    #   pack, dry, frozen no snowfall and no melt is possible, so the pack's
+    #                     own mass loss is the sublimated mass
+    #                                                  LE = lambda_v L + lambda_s S
+    #   pack, otherwise   melt and sublimation are not separable from what the
+    #                     model reports, so the criterion asserts only the
+    #                     interval the two latent heats span
+    #                                     lambda_v(T) E <= LE <= lambda_s E
+    #
+    # The interval is weaker on purpose. Asserting a split the model never
+    # reported would fail an honest model whose snow physics differs from the
+    # reference's, and a criterion that does that is worse than no criterion.
+    subl = np.zeros_like(et_mass)
+    inferable = np.ones_like(et_mass, dtype=bool)
+    split_steps = 0
+    if phase_state and phase_state in w.table.columns and snowfall_var in w.forcing.columns:
+        snw = w.table[phase_state].to_numpy(dtype=float)
+        prior = float(w.state0[phase_state]) if phase_state in w.state0.index else snw[0]
+        previous = np.concatenate(([prior], snw[:-1]))
+        frozen_and_dry = (w.forcing[snowfall_var].to_numpy(dtype=float) <= 0.0) & (
+            tas < snow_threshold
+        )
+        # A step is snow-free only if none could have arrived during it. A
+        # pack that falls and sublimates away inside one step begins and ends
+        # at zero, and asserting the liquid equality there would fail a model
+        # that handled it correctly.
+        snowfall = (w.forcing[snowfall_var].to_numpy(dtype=float) > 0.0) & (
+            tas < snow_threshold
+        )
+        no_pack = (previous <= 0.0) & (snw <= 0.0) & ~snowfall
+        pack_loss = np.clip(previous - snw, 0.0, None)
+        subl = np.where(frozen_and_dry, np.minimum(pack_loss, np.clip(et_mass, 0.0, None)), 0.0)
+        inferable = no_pack | frozen_and_dry
+        split_steps = int((subl > 0).sum())
+
+    equality = (lam_v * (et_mass - subl) + lam_s * subl) / seconds
+    spanned = np.stack([lam_v * et_mass / seconds, lam_s * et_mass / seconds])
+    lower = np.where(inferable, equality, spanned.min(axis=0))
+    upper = np.where(inferable, equality, spanned.max(axis=0))
+
+    tolerance = np.maximum(rel_tol * np.abs(le), abs_floor)
+    residual = np.where(le < lower, le - lower, np.where(le > upper, le - upper, 0.0))
+    slack = np.abs(residual) / tolerance
+    violating = slack > 1.0
+    required = np.clip(le, lower, upper)
+
+    # The implied bulk latent heat is the single most readable diagnostic: a
+    # model using a constant lambda reports the constant back, and one that
+    # ignores sublimation reports a number below lambda_v.
+    total_mass = float(et_mass.sum())
+    implied = float((le * dt * SECONDS_PER_DAY).sum() / total_mass) if total_mass > 0 else float("nan")
+
+    liquid = inferable & (subl <= 0.0)
+    worst = float(slack.max()) if slack.size else 0.0
+    n_bad = int(violating.sum())
+    ok = n_bad == 0
+
+    def worst_in(mask):
+        return float(slack[mask].max()) if mask.any() else 0.0
+
+    detail = (
+        f"implied lambda {implied:.4g} J/kg; worst step {worst:.2f} of tolerance "
+        f"(liquid {worst_in(liquid):.2f}, sublimating {worst_in(subl > 0.0):.2f} "
+        f"over {split_steps} steps, bounded {worst_in(~inferable):.2f} over "
+        f"{int((~inferable).sum())})"
+    )
+    if ok:
+        message = f"latent heat matches the reported evaporation at every step: {detail}"
+    else:
+        first = int(violating.argmax())
+        message = (
+            f"latent heat contradicts the reported evaporation on {n_bad} of "
+            f"{len(le)} steps, first at index {first} "
+            f"({le[first]:.3f} W m-2 reported, {required[first]:.3f} required); {detail}"
+        )
+
+    return CriterionResult(
+        name="flux_identity",
+        status=PASS if ok else FAIL,
+        value=worst,
+        threshold=1.0,
+        message=message,
+        diagnostics={
+            "implied_lambda_j_per_kg": implied,
+            "worst_slack": worst,
+            "worst_slack_liquid": worst_in(liquid),
+            "worst_slack_sublimating": worst_in(subl > 0.0),
+            "worst_slack_bounded": worst_in(~inferable),
+            "bounded_steps": int((~inferable).sum()),
+            "violating_steps": n_bad,
+            "sublimating_steps": split_steps,
+            "rel_tol": rel_tol,
+            "abs_floor_w_m2": abs_floor,
+        },
+    )
+
+
+@criterion("energy_closure")
+def energy_closure(run: RunResult, probe: ProbeSpec, params: dict) -> CriterionResult:
+    """Net radiation must be accounted for by the fluxes leaving the surface.
+
+    Separate from `closure` rather than a denominator of it, because `closure`
+    differences the probe's water states and this budget has none: `hfg` is
+    the storage term, and a model that reports it has already said where the
+    energy went. Keeping them apart also lets one probe score both budgets
+    without two criteria of the same name.
+
+    Net radiation changes sign every night, so the relative test carries an
+    absolute floor as the module docstring of `closure` prescribes.
+    """
+    driver = str(params.get("driver", "rn"))
+    sinks = list(params.get("sinks", ["hfls", "hfss", "hfg"]))
+    threshold = float(params.get("threshold", 0.05))
+    floor = float(params.get("floor", 2.0))
+
+    w = make_window(run, probe)
+    if driver not in w.forcing.columns:
+        raise ValueError(
+            f"energy_closure needs forcing column '{driver}'; this probe's "
+            "generator does not produce it"
+        )
+
+    # The driver is taken from the forcing, never from what the model echoed
+    # back, for the same reason `closure` does it: a model must not be able to
+    # move its own denominator.
+    drive = w.volume(w.forcing[driver].to_numpy(dtype=float))
+    outflow = np.zeros(len(w.table))
+    for var in sinks:
+        if var not in w.table.columns:
+            raise ValueError(f"energy_closure needs '{var}' in the model result")
+        outflow += w.volume(w.table[var].to_numpy(dtype=float))
+
+    step_residual = drive - outflow
+    cumulative = float(step_residual.sum())
+    total = float(np.abs(drive).sum())
+    if total <= 0:
+        return CriterionResult(
+            name="energy_closure",
+            status=FAIL,
+            message=f"accumulated |{driver}| is zero; the case is degenerate",
+        )
+
+    relative = abs(cumulative) / total
+    mean_abs = float(np.abs(step_residual).mean() / w.dt_days)
+    ok = relative <= threshold or mean_abs <= floor
+
+    return CriterionResult(
+        name="energy_closure",
+        status=PASS if ok else FAIL,
+        value=relative,
+        threshold=threshold,
+        message=(
+            f"cumulative residual {relative:.4%} of accumulated |{driver}| "
+            f"(limit {threshold:.1%}, floor {floor:g} W m-2; "
+            f"mean step residual {mean_abs:.3g} W m-2)"
+        ),
+        diagnostics={
+            "cumulative_residual": cumulative,
+            "denominator_total": total,
+            "mean_step_residual_w_m2": mean_abs,
+            "max_step_residual_w_m2": float(np.abs(step_residual).max() / w.dt_days),
+            "floor_w_m2": floor,
+        },
+    )

--- a/src/hydroturing/criteria/coherence.py
+++ b/src/hydroturing/criteria/coherence.py
@@ -24,15 +24,20 @@ and takes `lambda_s = lambda_v(0) + lambda_f`, 13.3 percent more energy per
 kilogram. A model that converts every kilogram at the vaporisation rate is
 short of that on exactly the steps where snow is disappearing.
 
-The sublimated mass is not assumed. On a step with no precipitation and air
-below freezing, no snow can fall and none can melt, so any decrease in the
-snow water equivalent the model itself reported is sublimation. Where the
-split cannot be inferred that way, because a pack is present and melting is
-possible, the criterion asserts only the interval that the two latent heats
-span rather than an equality. A criterion that failed an honest model whose
-snow physics differs from the reference's would be worse than no criterion,
-and a model that declines to report a snow state simply has the split
-disabled rather than being judged against an assumption about it.
+The sublimated mass is never inferred. A model that reports `sbl`, the
+sublimating share of its evaporation, is held to the equality at every step,
+because it has said which kilograms left as ice. A model that does not report
+it is held only to the interval the two latent heats span, wherever a pack is
+present or could arrive during the step.
+
+An earlier version inferred the split instead, reading any loss from the snow
+store on a dry sub-freezing day as sublimation. That is wrong, and review
+caught it: a pack also loses water at its base, which is what Snow-17's DAYGM
+term does. An honest model running a constant ground melt of 0.3 mm/day failed
+on about 400 steps of 3650 while its latent heat was exactly right, and at
+0.1 mm/day it passed with only 20 percent of the tolerance to spare. Asking
+the model rather than guessing costs one optional variable and removes the
+whole class of error.
 
 Related work. Enforcing conservation inside a neural emulator, and measuring
 the "physical inconsistency" left over when it is not enforced, is established
@@ -45,6 +50,7 @@ and energy budgets, evaluated as a residual the model cannot fit away.
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 
 from hydroturing.criteria.base import FAIL, PASS, CriterionResult, criterion, make_window
 from hydroturing.protocol import RunResult
@@ -75,6 +81,7 @@ def flux_identity(run: RunResult, probe: ProbeSpec, params: dict) -> CriterionRe
     phase_state = params.get("phase_state", "snw")
     snowfall_var = str(params.get("snowfall_from", "pr"))
     snow_threshold = float(params.get("snow_threshold_degC", 0.0))
+    sublimation_var = params.get("sublimation", "sbl")
 
     w = make_window(run, probe)
     for var in (flux, water):
@@ -96,50 +103,64 @@ def flux_identity(run: RunResult, probe: ProbeSpec, params: dict) -> CriterionRe
     lam_s = lam_a + lam_f
     seconds = dt * SECONDS_PER_DAY
 
-    # Every step falls into one of three cases, and only two of them are an
-    # equality. Which case a step is in is decided from the forcing and the
-    # model's own snow state, never from an assumption about how the model
-    # partitions evaporation.
+    # Two regimes, and which one a step is in depends on what the model chose
+    # to report rather than on anything this criterion assumes about snow.
     #
-    #   no pack           all of it is liquid          LE = lambda_v(T) E
-    #   pack, dry, frozen no snowfall and no melt is possible, so the pack's
-    #                     own mass loss is the sublimated mass
-    #                                                  LE = lambda_v L + lambda_s S
-    #   pack, otherwise   melt and sublimation are not separable from what the
-    #                     model reports, so the criterion asserts only the
-    #                     interval the two latent heats span
-    #                                     lambda_v(T) E <= LE <= lambda_s E
+    #   reports `sbl`      it has said which kilograms left as ice, so the
+    #                      equality holds at every step, pack or no pack:
+    #                          LE = lambda_v (E - sbl) + lambda_s sbl
     #
-    # The interval is weaker on purpose. Asserting a split the model never
-    # reported would fail an honest model whose snow physics differs from the
-    # reference's, and a criterion that does that is worse than no criterion.
+    #   reports no `sbl`   snow-free steps where none could fall are still an
+    #                      equality at lambda_v; anywhere a pack is or could
+    #                      be present, only the interval:
+    #                          lambda_v(T) E <= LE <= lambda_s E
+    #
+    # The interval is the honest bound on a model that has not told us, and it
+    # is weak on purpose. A pack loses water to more than sublimation --
+    # Snow-17's DAYGM puts it into the soil -- so a criterion that read the
+    # pack's own mass loss as sublimation would fail an honest model.
     subl = np.zeros_like(et_mass)
-    inferable = np.ones_like(et_mass, dtype=bool)
-    split_steps = 0
+    reported_split = bool(sublimation_var) and sublimation_var in w.table.columns
+    if reported_split:
+        column = pd.to_numeric(w.table[sublimation_var], errors="coerce").to_numpy(dtype=float)
+        if not np.isfinite(column).all():
+            raise ValueError(f"column {sublimation_var!r} has non-finite values")
+        subl = column * dt
+
+    pack_possible = np.ones_like(et_mass, dtype=bool)
     if phase_state and phase_state in w.table.columns and snowfall_var in w.forcing.columns:
         snw = w.table[phase_state].to_numpy(dtype=float)
         prior = float(w.state0[phase_state]) if phase_state in w.state0.index else snw[0]
         previous = np.concatenate(([prior], snw[:-1]))
-        frozen_and_dry = (w.forcing[snowfall_var].to_numpy(dtype=float) <= 0.0) & (
-            tas < snow_threshold
-        )
-        # A step is snow-free only if none could have arrived during it. A
-        # pack that falls and sublimates away inside one step begins and ends
-        # at zero, and asserting the liquid equality there would fail a model
-        # that handled it correctly.
-        snowfall = (w.forcing[snowfall_var].to_numpy(dtype=float) > 0.0) & (
-            tas < snow_threshold
-        )
-        no_pack = (previous <= 0.0) & (snw <= 0.0) & ~snowfall
-        pack_loss = np.clip(previous - snw, 0.0, None)
-        subl = np.where(frozen_and_dry, np.minimum(pack_loss, np.clip(et_mass, 0.0, None)), 0.0)
-        inferable = no_pack | frozen_and_dry
-        split_steps = int((subl > 0).sum())
+        # A step is snow-free only if none could arrive during it: a pack that
+        # falls and disappears inside one step begins and ends at zero.
+        snowfall = (w.forcing[snowfall_var].to_numpy(dtype=float) > 0.0) & (tas < snow_threshold)
+        pack_possible = (previous > 0.0) | (snw > 0.0) | snowfall
 
-    equality = (lam_v * (et_mass - subl) + lam_s * subl) / seconds
-    spanned = np.stack([lam_v * et_mass / seconds, lam_s * et_mass / seconds])
-    lower = np.where(inferable, equality, spanned.min(axis=0))
-    upper = np.where(inferable, equality, spanned.max(axis=0))
+    failures: list[str] = []
+    if reported_split:
+        # The split is a claim about the model's own evaporation, so it has to
+        # be one: never negative, never more than what evaporated, and zero
+        # where the model itself reports no ice to lose. Without the last of
+        # these, a model could report a fictitious sublimating share to bend
+        # its effective lambda upwards on a warm day.
+        checks = (
+            (subl < -1e-9, "negative"),
+            (subl > np.maximum(et_mass, 0.0) + 1e-9,
+             "larger than the evaporation it is a share of"),
+            ((~pack_possible) & (subl > 1e-9),
+             "non-zero where the model reports no snow and none could fall"),
+        )
+        for mask, what in checks:
+            if mask.any():
+                failures.append(f"{sublimation_var!r} is {what} on {int(mask.sum())} steps")
+        equality = (lam_v * (et_mass - subl) + lam_s * subl) / seconds
+        lower = upper = equality
+    else:
+        liquid_only = lam_v * et_mass / seconds
+        spanned = np.stack([liquid_only, lam_s * et_mass / seconds])
+        lower = np.where(pack_possible, spanned.min(axis=0), liquid_only)
+        upper = np.where(pack_possible, spanned.max(axis=0), liquid_only)
 
     tolerance = np.maximum(rel_tol * np.abs(le), abs_floor)
     residual = np.where(le < lower, le - lower, np.where(le > upper, le - upper, 0.0))
@@ -153,21 +174,30 @@ def flux_identity(run: RunResult, probe: ProbeSpec, params: dict) -> CriterionRe
     total_mass = float(et_mass.sum())
     implied = float((le * dt * SECONDS_PER_DAY).sum() / total_mass) if total_mass > 0 else float("nan")
 
-    liquid = inferable & (subl <= 0.0)
+    bounded = pack_possible & (not reported_split)
     worst = float(slack.max()) if slack.size else 0.0
     n_bad = int(violating.sum())
-    ok = n_bad == 0
+    ok = n_bad == 0 and not failures
 
     def worst_in(mask):
         return float(slack[mask].max()) if mask.any() else 0.0
 
-    detail = (
-        f"implied lambda {implied:.4g} J/kg; worst step {worst:.2f} of tolerance "
-        f"(liquid {worst_in(liquid):.2f}, sublimating {worst_in(subl > 0.0):.2f} "
-        f"over {split_steps} steps, bounded {worst_in(~inferable):.2f} over "
-        f"{int((~inferable).sum())})"
-    )
-    if ok:
+    split_steps = int((subl > 0).sum())
+    detail = f"implied lambda {implied:.4g} J/kg; worst step {worst:.2f} of tolerance"
+    if reported_split:
+        detail += (
+            f" ({split_steps} steps report sublimation, worst there "
+            f"{worst_in(subl > 0):.2f})"
+        )
+    else:
+        detail += (
+            f" (equality on {int((~bounded).sum())} snow-free steps, interval on "
+            f"{int(bounded.sum())} where a pack is or could be present)"
+        )
+
+    if failures:
+        message = "; ".join(failures) + f" [{detail}]"
+    elif ok:
         message = f"latent heat matches the reported evaporation at every step: {detail}"
     else:
         first = int(violating.argmax())
@@ -186,10 +216,10 @@ def flux_identity(run: RunResult, probe: ProbeSpec, params: dict) -> CriterionRe
         diagnostics={
             "implied_lambda_j_per_kg": implied,
             "worst_slack": worst,
-            "worst_slack_liquid": worst_in(liquid),
             "worst_slack_sublimating": worst_in(subl > 0.0),
-            "worst_slack_bounded": worst_in(~inferable),
-            "bounded_steps": int((~inferable).sum()),
+            "worst_slack_bounded": worst_in(bounded),
+            "bounded_steps": int(bounded.sum()),
+            "reported_split": bool(reported_split),
             "violating_steps": n_bad,
             "sublimating_steps": split_steps,
             "rel_tol": rel_tol,

--- a/src/hydroturing/spec.py
+++ b/src/hydroturing/spec.py
@@ -23,7 +23,8 @@ SCHEMA_DIR = REPO_ROOT / "schemas"
 # fluxes are W m-2, positive away from the surface for the turbulent terms and
 # positive into the ground for `hfg`, which is the surface energy budget's
 # storage term: a model that reports it does not also need an energy state.
-FLUX_VARS = ("pr", "evspsbl", "mrro", "dis", "gwex", "hfls", "hfss", "hfg")
+# `sbl` is a component of `evspsbl`, never an addition to it.
+FLUX_VARS = ("pr", "evspsbl", "mrro", "dis", "gwex", "sbl", "hfls", "hfss", "hfg")
 STATE_VARS = ("mrso", "snw", "canopy", "gw", "channel")
 
 UNITS = {
@@ -32,6 +33,10 @@ UNITS = {
     "mrro": "mm day-1",
     "dis": "m3 s-1",
     "gwex": "mm day-1",
+    # The sublimating share of `evspsbl`, not a flux in addition to it. A model
+    # that reports it is stating which part of its evaporation left the surface
+    # as ice, which is the only way a criterion can know without guessing.
+    "sbl": "mm day-1",
     "hfls": "W m-2",
     "hfss": "W m-2",
     "hfg": "W m-2",

--- a/src/hydroturing/spec.py
+++ b/src/hydroturing/spec.py
@@ -18,9 +18,12 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_DIR = REPO_ROOT / "schemas"
 
-# Canonical variable names. Fluxes are mm per timestep-day; states are mm.
-# `dis` is the one exception and is m3 s-1, because that is what models report.
-FLUX_VARS = ("pr", "evspsbl", "mrro", "dis", "gwex")
+# Canonical variable names. Water fluxes are mm per timestep-day; states are
+# mm. `dis` is m3 s-1, because that is what models report. The surface energy
+# fluxes are W m-2, positive away from the surface for the turbulent terms and
+# positive into the ground for `hfg`, which is the surface energy budget's
+# storage term: a model that reports it does not also need an energy state.
+FLUX_VARS = ("pr", "evspsbl", "mrro", "dis", "gwex", "hfls", "hfss", "hfg")
 STATE_VARS = ("mrso", "snw", "canopy", "gw", "channel")
 
 UNITS = {
@@ -29,6 +32,9 @@ UNITS = {
     "mrro": "mm day-1",
     "dis": "m3 s-1",
     "gwex": "mm day-1",
+    "hfls": "W m-2",
+    "hfss": "W m-2",
+    "hfg": "W m-2",
     "mrso": "mm",
     "snw": "mm",
     "canopy": "mm",
@@ -60,6 +66,11 @@ FULL_WINDOW = "full"
 # container boundary. A submitted manifest cannot opt itself into host access.
 TRUSTED_SUBPROCESS_MODELS = {
     "reference_bucket",
+    "reference_coupled",
+    "reference_two_head",
+    "reference_constant_lambda",
+    "reference_sublimation_blind",
+    "reference_energy_leak",
     "reference_calendar",
     "reference_cheater",
     "reference_degenerate",

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -1,0 +1,165 @@
+"""The latent heat a model reports and the water it evaporates have to
+describe one evaporation. These test `flux_identity` on tables written by
+hand, because the gate alone cannot say which of its branches did the work,
+and because the branch that used to guess the sublimating share needed a
+counterexample rather than a green gate to be found."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hydroturing.criteria import get
+from hydroturing.criteria.base import PASS
+from hydroturing.protocol import Case, RunResult
+
+LAMBDA_A, LAMBDA_B = 2.501e6, -2361.0
+LAMBDA_F = 3.337e5
+SECONDS = 86400.0
+SPINUP = 5
+N = 200
+
+
+def lambda_v(tas):
+    return LAMBDA_A + LAMBDA_B * tas
+
+
+def build(evspsbl, tas, hfls, snw, pr, sbl=None):
+    """One run of a made-up model, as the criterion receives it.
+
+    `snw=None` is a model that reports no snow state at all."""
+    columns = {"time": np.arange(N), "evspsbl": evspsbl, "hfls": hfls}
+    if snw is not None:
+        columns["snw"] = snw
+    if sbl is not None:
+        columns["sbl"] = sbl
+    forcing = pd.DataFrame({"time": np.arange(N), "pr": pr, "tas": tas})
+    case = Case(probe_id="t", seed=1, forcing=forcing, static={}, spinup_steps=SPINUP)
+    return RunResult(case=case, table=pd.DataFrame(columns), meta={}, wall_seconds=0.0)
+
+
+@pytest.fixture
+def winter():
+    """Half the record below freezing with a pack, half hot and snow-free.
+
+    The warm half is hot and evaporating hard on purpose: the error a constant
+    latent heat makes is 3.4 percent at most, so a test that wants to see it
+    has to look where lambda_v is furthest from the constant and where there
+    is enough water moving for the absolute floor not to swallow it."""
+    tas = np.concatenate([np.full(N // 2, -6.0), np.full(N // 2, 32.0)])
+    pr = np.zeros(N)
+    pr[10:20] = 4.0                      # snowfall, since it is below freezing
+    snw = np.where(np.arange(N) < N // 2, 50.0, 0.0)
+    evspsbl = np.where(np.arange(N) < N // 2, 1.5, 5.0)
+    return tas, pr, snw, evspsbl
+
+
+def run(**kwargs):
+    return get("flux_identity")(build(**kwargs), None, {})
+
+
+def test_the_exact_identity_passes(winter):
+    tas, pr, snw, evspsbl = winter
+    sbl = np.where(snw > 0, evspsbl, 0.0)
+    hfls = (lambda_v(tas) * (evspsbl - sbl) + (LAMBDA_A + LAMBDA_F) * sbl) / SECONDS
+    result = run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=snw, pr=pr, sbl=sbl)
+    assert result.status == PASS, result.message
+    assert result.diagnostics["reported_split"] is True
+
+
+def test_a_constant_latent_heat_is_caught(winter):
+    tas, pr, snw, evspsbl = winter
+    sbl = np.where(snw > 0, evspsbl, 0.0)
+    hfls = 2.45e6 * evspsbl / SECONDS
+    assert run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=snw, pr=pr, sbl=sbl).status != PASS
+
+
+def test_vaporisation_applied_to_sublimation_is_caught(winter):
+    """The reported split says these kilograms left as ice; charging them at
+    the latent heat of vaporisation is 13.3 percent short."""
+    tas, pr, snw, evspsbl = winter
+    sbl = np.where(snw > 0, evspsbl, 0.0)
+    hfls = lambda_v(tas) * evspsbl / SECONDS
+    result = run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=snw, pr=pr, sbl=sbl)
+    assert result.status != PASS
+    assert result.diagnostics["violating_steps"] > 0
+
+
+def test_a_pack_that_loses_water_at_its_base_is_not_a_violation(winter):
+    """Snow-17's DAYGM moves water from the pack into the soil without any
+    latent heat. The pack's mass loss is therefore not the sublimated mass,
+    and a criterion that reads it as such fails an honest model. This is the
+    counterexample the first version of the criterion did not survive."""
+    tas, pr, snw, evspsbl = winter
+    # The pack drains 0.3 mm/day at its base on top of the 1.5 mm/day that
+    # sublimates, so the store falls faster than the evaporation alone would
+    # explain. Under the old inference the extra 0.3 was charged the latent
+    # heat of sublimation and the model was told it had violated physics.
+    step = np.arange(N)
+    snw = np.where(step < N // 2, np.clip(400.0 - 1.8 * step, 0.0, None), 0.0)
+    sbl = np.where(snw > 0, evspsbl, 0.0)
+    hfls = (lambda_v(tas) * (evspsbl - sbl) + (LAMBDA_A + LAMBDA_F) * sbl) / SECONDS
+    assert run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=snw, pr=pr, sbl=sbl).status == PASS
+
+
+def test_a_model_that_reports_no_split_is_bounded_not_guessed_at(winter):
+    """Without `sbl` the criterion asserts only the interval the two latent
+    heats span wherever a pack is or could be present. Both extremes pass;
+    a value outside them does not."""
+    tas, pr, snw, evspsbl = winter
+    inside_low = lambda_v(tas) * evspsbl / SECONDS
+    inside_high = np.where(snw > 0, (LAMBDA_A + LAMBDA_F) * evspsbl / SECONDS, inside_low)
+    outside = np.where(snw > 0, 3.2e6 * evspsbl / SECONDS, inside_low)
+
+    for hfls in (inside_low, inside_high):
+        r = run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=snw, pr=pr)
+        assert r.status == PASS, r.message
+        assert r.diagnostics["reported_split"] is False
+    assert run(evspsbl=evspsbl, tas=tas, hfls=outside, snw=snw, pr=pr).status != PASS
+
+
+def test_snow_free_steps_are_still_an_equality_without_a_split(winter):
+    """The interval is only for steps where a pack is or could be present.
+    Where the model reports none and none can fall, lambda_v is exact, which
+    is what keeps a constant-lambda model catchable when it reports no split."""
+    tas, pr, snw, evspsbl = winter
+    hfls = np.where(snw > 0, lambda_v(tas), 2.45e6) * evspsbl / SECONDS
+    assert run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=snw, pr=pr).status != PASS
+
+
+def test_a_fictitious_split_is_rejected(winter):
+    """A split reported where the model itself says there is no snow would let
+    a warm-season model bend its effective lambda upwards."""
+    tas, pr, snw, evspsbl = winter
+    sbl = np.full(N, 1.5)                       # claimed even where snw is zero
+    hfls = (LAMBDA_A + LAMBDA_F) * evspsbl / SECONDS
+    result = run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=snw, pr=pr, sbl=sbl)
+    assert result.status != PASS
+    assert "no snow" in result.message
+
+
+def test_a_split_larger_than_the_evaporation_is_rejected(winter):
+    tas, pr, snw, evspsbl = winter
+    sbl = np.where(snw > 0, evspsbl * 2.0, 0.0)
+    hfls = (LAMBDA_A + LAMBDA_F) * evspsbl / SECONDS
+    result = run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=snw, pr=pr, sbl=sbl)
+    assert result.status != PASS
+    assert "share of" in result.message
+
+
+def test_a_model_with_no_snow_state_is_bounded_everywhere(winter):
+    """A model that reports no snow store has told us nothing about phase, so
+    every step is one where a pack could be present and the interval is all
+    the criterion may assert. Holding such a model to the liquid equality
+    would be an implicit assumption that it never sublimates."""
+    tas, pr, _, evspsbl = winter
+    sublimating = (LAMBDA_A + LAMBDA_F) * evspsbl / SECONDS
+    liquid = lambda_v(tas) * evspsbl / SECONDS
+    outside = 3.2e6 * evspsbl / SECONDS
+
+    for hfls in (liquid, sublimating):
+        r = run(evspsbl=evspsbl, tas=tas, hfls=hfls, snw=None, pr=pr)
+        assert r.status == PASS, r.message
+        assert r.diagnostics["bounded_steps"] == len(tas) - SPINUP
+    assert run(evspsbl=evspsbl, tas=tas, hfls=outside, snw=None, pr=pr).status != PASS

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -240,7 +240,7 @@ def test_cli_window_and_csv_flags(probe, tmp_path, capsys):
 
     archive = tmp_path / "result.csv"
     code = main([
-        "run", "--model", "reference_bucket", "--seed", "11",
+        "run", "--model", "reference_bucket", "--probe", probe.id, "--seed", "11",
         "--window", "30", "--csv", str(archive),
     ])
     assert code == 0
@@ -270,7 +270,10 @@ def test_contract_check_can_be_archived(probe, tmp_path):
     from hydroturing.cli import main
 
     archive = tmp_path / "result.csv"
-    assert main(["verify-adapter", "--model", "reference_streamflow_only", "--csv", str(archive)]) == 0
+    assert main([
+        "verify-adapter", "--model", "reference_streamflow_only",
+        "--probe", probe.id, "--csv", str(archive),
+    ]) == 0
     with open(archive, newline="") as fh:
         (row,) = list(csv.DictReader(fh))
     assert row["probe"] == "mass/catchment-closure (adapter contract)"


### PR DESCRIPTION
Closes #3

The first of two. PR2 (`energy/evaporative-partition`) is stacked on this one and reuses its vocabulary, its `energy_closure` criterion and its reference models. This PR stands alone — 15 probes, 28 models, `ht gate` green with nothing from PR2 present. PR2 does not stand alone.

This is the ROADMAP item `coupled/latent-heat-et-consistency`, filed under `energy` because `probe.schema.json` and the proposal form admit only mass, energy and momentum. `energy/pet-consistency` shows that is the right shelf for a probe about evaporation whatever variables it happens to need.

## What this probe asserts

A model with a water head and an energy head can close its water budget to floating point, close its energy budget to floating point, and still report a latent heat flux implying a different evaporation than the one it reported as water. The contradiction lives strictly between the ledgers, so no single-budget criterion can reach it.

**R1 — the identity, at every step**

    R1(t) = hfls(t) - lambda(T, phase) * evspsbl(t) * rho_w / 86400   [W m-2]

    lambda_v(T) = 2.501e6 - 2361 * T                  [J kg-1], T in degC
    lambda_s    = lambda_v(0) + lambda_f = 2.835e6    [J kg-1]

A failure means the model is describing two different evaporations and calling them one. Physically: the water leaving the surface was never converted to energy by any process — the two numbers were produced independently and never had to agree.

**R2 — the surface energy budget**

    R2(t) = rn(t) - hfls(t) - hfss(t) - hfg(t)                       [W m-2]

`hfg` is the storage term, so no energy state has to be declared. A model that declines to report it is INCOMPLETE, not in violation.

**R0 — the water budget**, on the same terms as `mass/catchment-closure`. A claim about incoherence between two ledgers means nothing unless each ledger is closed on its own terms, so this probe scores both.

### Tolerances, and why R1 is not five percent

A constant latent heat of vaporisation is wrong by **at most 3.4 percent** over a -20 to +35 degC record. The engineering rule cannot see the most likely failure mode, so R1 is scored per step against **0.5 percent** of the reported flux.

The absolute floor is **0.5 W m-2, not 2**. I tried 2 first, reasoning that it is a negligible flux. It is not a negligible tolerance: at 2 W m-2 `reference_constant_lambda` trips 4 steps of 3650 with a worst step at 1.52 times tolerance, instead of 33 steps at 6.08. That is not a margin, and another seed could let it through. At 0.5 the exact model still passes with a worst step of 0.00.

### The objection this will always draw

*Observed surface energy budgets do not close. How can a benchmark demand half a percent?*

They do not, and the gap is documented: closure at eddy covariance sites varies systematically in space and time (Cui & Chui 2019), and a recent correction across 172 flux towers moves the mean imbalance from -14.99 to -0.65 W m-2 (Zhang et al. 2024) — a raw imbalance of order 15 W m-2, about thirty times this probe's floor.

That is exactly why the test belongs on the synthetic track and measures a model against itself. If an observed budget were the reference, no tolerance would be defensible, because the reference would be the thing that does not close. ROADMAP already says this of the real-data track: "observed budgets do not close, so observations can never be the reference." This is the same argument applied to the energy budget, and the reason `flux_identity` should never be ported there. The README carries this in full.

### The phase change, and what is deliberately not asserted

`lambda_s / lambda_v(0) = 1.133`. A model converting every kilogram at the vaporisation rate is short by 13.3 percent on exactly the steps where a pack is losing mass to the atmosphere.

The sublimated mass is never assumed. Each step falls into one of three cases, decided from the forcing and the model's own snow state:

| Case | Asserted |
| --- | --- |
| No pack, and none can fall during the step | `LE = lambda_v(T) E` |
| Pack, no precipitation, air below freezing: nothing can fall and nothing can melt, so the pack's own reported loss is the sublimated mass | `LE = lambda_v L + lambda_s S` |
| Pack, anything else | `lambda_v(T) E <= LE <= lambda_s E` |

The third case is weak because of a bug the gate caught. My first version asserted the equality everywhere and **failed the exact model**: the reference sublimates whenever a pack is present, while the criterion could only infer the split on dry frozen steps. The fix is not to change the model to match the criterion — that is circular — but to have the criterion assert only what it can establish from what the model reported. A criterion that fails an honest model whose snow physics differs from the reference's is worse than no criterion.

Discrimination survives: `reference_sublimation_blind` is caught on the second case, which this record supplies about 400 steps of per seed.

(A second boundary the gate found, kept as a comment: snow that falls and sublimates away inside one step leaves SWE at zero on both sides, so "no pack" must also exclude steps where snow could have fallen.)

### The case

`generate.py`, seeded, 10 years plus a year of spinup, 5 seeds. The water side is the record of `mass/catchment-closure` unchanged. Two things are added.

Net radiation from a clear-sky cycle at 40 degN, attenuated by its own AR(1) cloudiness process, with an albedo that switches below freezing and an outgoing longwave term following air temperature. It crosses zero on winter days, which is why the energy criteria carry floors.

PET is then **derived from that net radiation** by Priestley-Taylor with alpha = 1.26 rather than being an independent function of temperature. A reviewer will ask why demand and available energy in a coherence probe are consistent with one another; this is the answer. They are not two forcings, they are one. The consequence that matters is that PET stays small but non-zero on cold clear days — without which no snowpack ever sublimates and half of R1 has nothing to score.

Typical record: ~800 mm/yr precipitation, ~550 mm/yr PET, net radiation averaging 79 W m-2, ~550 dry sub-zero days in 4015.

### Prior art

Beucler et al. (2021) enforce analytic constraints in neural networks emulating convection, architecturally or through the loss, and quantify the "physical inconsistency" that remains across mass, momentum, radiation and energy budgets. That is the nearest prior art and the README credits it. What differs here: a binary verdict rather than a penalty term, because a benchmark must be able to reject; and a catchment's surface budgets rather than a convective column's.

## Discrimination

`ht gate --probe energy/latent-heat-et-consistency` — GATE PASSED, seeds [1415376846, 1922328960, 281797427, 788749541, 1295701655].

The template's default rows are the mass probe's models; this probe declares its own, all five new in this PR.

| Reference model | Expected | Criterion that catches it |
| --- | --- | --- |
| `reference_coupled` | PASS | n/a — exact by construction, must pass everything |
| `reference_two_head` | FAIL | `flux_identity` |
| `reference_constant_lambda` | FAIL | `flux_identity` |
| `reference_sublimation_blind` | FAIL | `flux_identity` |
| `reference_energy_leak` | FAIL | `energy_closure` |
| `reference_bucket` | INCOMPLETE | reports no energy fluxes |

`reference_two_head` is the model ROADMAP asks for — "closes both budgets separately but incoherently". Water side is the exact bucket; energy side partitions net radiation by a fixed climatological evaporative fraction that never reads the soil. Both budgets close to 1e-15. Implied bulk lambda 3.13e6 J kg-1 against a true 2.46e6, on 3495 steps of 3650:

    ok    closure          cumulative residual 0.0000% of sum_pr (limit 5.0%)
    ok    energy_closure   cumulative residual 0.0000% of accumulated |rn|
    FAIL  flux_identity    latent heat contradicts the reported evaporation on
                           3495 of 3650 steps, first at index 0 (94.257 W m-2
                           reported, 81.488 required); implied lambda 3.128e+06

`reference_constant_lambda` and `reference_sublimation_blind` each break one half of `flux_identity` and nothing else, so neither half goes untested. `reference_energy_leak` is the energy counterpart of `reference_leaky`.

## What this changes outside the probe

**1. Vocabulary.** `hfls`, `hfss`, `hfg` join `FLUX_VARS` and `UNITS` in W m-2, alongside `gwex`. Three lines in `spec.py`. **The JSON schemas need no change**: they never enumerated variable names, only `emits.fluxes` as free strings.

**2. `energy_closure` is a new criterion rather than a denominator of `closure`.** `closure` unconditionally differences `probe.requires_states`, which here are the water states in mm. Keeping them separate also lets one probe score both budgets without two criteria of the same name. `DENOMINATORS` already carried `sum_abs_rn` and the module docstring already anticipated the sign change, so the intent was there; only the states coupling was in the way.

**3. `reference_bucket` is now INCOMPLETE on this probe**, so `ht run --model reference_bucket` no longer passes the whole suite. This is the correct verdict rather than a regression — it has not violated conservation of energy, it has declined to be falsifiable about it, exactly as `reference_streamflow_only` does on the budget probes today. But it changes the README's headline example, and two tests in `tests/test_window.py` assumed both that the first probe in registry order is `mass/catchment-closure` and that a water-only model passes the whole suite. Neither holds once the suite has a probe that requires energy fluxes. I scoped those two tests to their fixture's probe, which also makes them robust to any future probe sorting ahead of the mass ones. I have not touched the README; say which way you want it and I will.

**4. `must_pass` names `reference_coupled` alone.** The mass probes now require `[reference_bucket, flex_lumped, flex_topo, sacsma_snow17]`, and I would have followed that, but all four return INCOMPLETE here — `missing: hfls, hfss, hfg`. That is the correct verdict and worth stating plainly: every hand-written physical model in the suite, including the one added this week, cannot currently be checked for energy at all. Supplying an exact model that can is most of what this PR does.

## Checklist

- [x] `ht validate` passes — 15 probes, 28 models with this PR alone
- [x] `ht gate --probe energy/latent-heat-et-consistency` passes
- [x] `ht gate` (whole suite) passes
- [x] `pytest -q` shows no change against the pristine tree — 18 failed / 92 passed before and after; the failures are pre-existing and environmental on my Windows box
- [x] The generator is deterministic given a seed and commits no data
- [x] The probe runs in under a minute on a two-core runner — the full gate for this probe is 4.1 s
- [x] Tolerance and denominator are justified in `probe.yaml`, with the measurement that set the floor
- [x] I constructed a model that passes closure without doing physics — `reference_two_head` closes both budgets to 1e-15 — and `flux_identity` catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)