### PR TITLE
[PROBE: energy] Detect cancelling errors in hourly surface energy budgets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,12 +127,21 @@ numbers in both runs; keep it that way and do not reseed from the clock.
 | `sbl` | the sublimating share of `evspsbl`: a component of it, never an addition; report it if the model knows which kilograms left as ice | mm/day |
 | `hfls` | latent heat flux, positive away from the surface | W/m2 |
 | `hfss` | sensible heat flux, positive away from the surface | W/m2 |
-| `hfg` | ground heat flux, positive into the ground; the storage term of the surface energy budget, so no energy state is needed | W/m2 |
+| `hfg` | ground heat flux at the actual soil surface, positive into the ground; a flux taken below the surface must be corrected for heat storage above that depth | W/m2 |
 | `mrso` | soil water storage | mm |
 | `snw` | snow water equivalent | mm |
 | `canopy` | canopy interception storage | mm |
 | `gw` | groundwater storage below the soil column | mm |
 | `channel` | water generated as runoff but not yet released by the model's routing | mm |
+
+For `hfg`, an adapter mapping a plate-depth or deeper-boundary flux must use
+`G_surface = G_depth + (E_above_end - E_above_start) / dt`, with downward
+fluxes positive, `E_above` in J/m2 and `dt` in seconds. The storage and fluxes
+must cover the same area, layer and time interval; this relation assumes no
+other energy sources or sinks in that layer. Use the model's actual heat
+storage, not a value inferred from the surface-budget residual. Document the
+mapping and any unavailable terms. Once `hfg` is mapped to the surface, do
+not subtract subsurface heat storage again in the surface budget.
 
 A probe names the stores it requires. Report every store the model
 actually has, including ones the probe did not name: a groundwater zone

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,6 +17,12 @@ authors:
   - given-names: Siavash
     family-names: Shams
     # affiliation and orcid requested from the author, 2026-09-11
+  - given-names: Han
+    family-names: Wang
+    affiliation: >-
+      Department of Civil and Environmental Engineering,
+      The Hong Kong University of Science and Technology, Hong Kong, China
+    orcid: "https://orcid.org/0000-0001-9771-1324"
 repository-code: "https://github.com/Flood-Lab/HydroTuring"
 url: "https://flood-lab.github.io/HydroTuring/"
 license: MIT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,6 +31,7 @@ long.
 | `energy/pet-consistency` | Zhi Li (CU Boulder) |
 | `energy/latent-heat-et-consistency` | Changming Li (SCUT) |
 | `energy/evaporative-partition` | Changming Li (SCUT) |
+| `energy/surface-energy-closure` | Han Wang ([@cehw](https://github.com/cehw)) |
 | `momentum/routing-conservation` | Zhi Li (CU Boulder) |
 
 ## Models
@@ -46,7 +47,8 @@ evaluation is archived in [models/result.csv](models/result.csv).
 | `google_flood_forecast` | Zhi Li (CU Boulder), [#1](../../issues/1) | HydroTuring maintainers |
 | `dhbv2` | Zhi Li (CU Boulder), [#2](../../issues/2) | HydroTuring maintainers |
 
-Physical reference models, which every probe must pass:
+Physical reference models, which every compatible probe must pass when their
+outputs support its criteria:
 
 | Model | Author | Source |
 | --- | --- | --- |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,7 +31,7 @@ long.
 | `energy/pet-consistency` | Zhi Li (CU Boulder) |
 | `energy/latent-heat-et-consistency` | Changming Li (SCUT) |
 | `energy/evaporative-partition` | Changming Li (SCUT) |
-| `energy/surface-energy-closure` | Han Wang ([@cehw](https://github.com/cehw)) |
+| `energy/surface-energy-closure` | Han Wang (The Hong Kong University of Science and Technology) |
 | `momentum/routing-conservation` | Zhi Li (CU Boulder) |
 
 ## Models

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ not.
 
 ## The probes
 
-Seventeen: thirteen under mass, three under energy and one under momentum. Each was
+Eighteen: thirteen under mass, four under energy and one under momentum. Each was
 merged only after the acceptance gate saw it pass four physical models, a
 bucket that conserves water exactly, two hand-written FLEX models and the
 NWS's SAC-SMA with Snow-17, and fail a purpose-built broken one on the
 named criterion. A probe that fails a
 physical model is examined before the model is; that is the first thing done
-with any probe pull request. Eleven of the seventeen can be scored on a model
+with any probe pull request. Eleven of the eighteen can be scored on a model
 that reports runoff and nothing else. `ht list` prints them;
-[ROADMAP.md](ROADMAP.md#probes-we-want) has the fifteen more we want, all
+[ROADMAP.md](ROADMAP.md#probes-we-want) has the fourteen more we want, all
 unclaimed.
 
 | Probe | Law | What it asks | The broken model it catches |
@@ -97,6 +97,7 @@ unclaimed.
 | [`energy/pet-consistency`](probes/energy/pet-consistency) | energy | Evaporation reaches demand when the model's own soil is wettest, stays below it, and falls when the soil is driest. | `reference_thirsty` |
 | [`energy/latent-heat-et-consistency`](probes/energy/latent-heat-et-consistency) | energy | The evaporation a model reports as water and the evaporation implied by the latent heat it reports: are they the same evaporation? | `reference_two_head`, `reference_constant_lambda`, `reference_sublimation_blind`, `reference_energy_leak` |
 | [`energy/evaporative-partition`](probes/energy/evaporative-partition) | energy | One summer without rain under net radiation that did not change: the latent heat a drying surface gives up has to warm the air. | `reference_two_head`, `reference_ground_dodge` |
+| [`energy/surface-energy-closure`](probes/energy/surface-energy-closure) | energy | Does each day and night close its hourly surface energy budget, without opposite errors cancelling? | `reference_diurnal_bias` |
 | [`momentum/routing-conservation`](probes/momentum/routing-conservation) | momentum | The channel store is never negative and never holds more than its hydrograph can. | `reference_stuck_router` |
 
 ## Models
@@ -109,9 +110,10 @@ hand-written conceptual models from
 [chrimerss/HydrologicModels](https://github.com/chrimerss/HydrologicModels)
 and the NWS's SAC-SMA with Snow-17 must pass every probe that can ask them
 anything, so a probe that fails one is wrong until shown otherwise. All four
-report water and no energy, so all four are INCOMPLETE on the two probes
+report water and no energy, so all four are INCOMPLETE on the three probes
 that need the latent, sensible and ground heat fluxes,
-`energy/latent-heat-et-consistency` and `energy/evaporative-partition`,
+`energy/latent-heat-et-consistency`, `energy/evaporative-partition` and
+`energy/surface-energy-closure`,
 rather than passing them: they have not
 violated conservation of energy, they have declined to be falsifiable about
 it, exactly as `reference_streamflow_only` does on the budget probes. A broken model is broken in one specific way, so that no criterion
@@ -119,17 +121,18 @@ goes untested.
 
 | Model | Kind | What it does | Standing |
 | --- | --- | --- | --- |
-| [`google_flood_forecast`](models/google_flood_forecast) | submitted | The mean-embedding forecast LSTM behind Google Flood Hub, at the published weights. Predicts discharge and nothing else. | **FAIL (INCOMPLETE)**, 5 of 17 probes passed. Runoff-only, so six probes cannot ask it anything; of the eleven that ask on runoff alone it passes the runoff bounds, memory, area, causality and steady state, and fails step, extreme rain, phase, warming, dry-down, and a 0.18 mm/day dip after an added storm |
-| [`dhbv2`](models/dhbv2) | submitted | δHBV 2.0, the MHPI group's differentiable HBV: neural networks write the parameters of a bucket model that reports its stores and its evaporation. | **FAIL (VIOLATION)**, 11 of 17 probes passed. Its learned regional-groundwater term, declared as `gwex`, closes the budget to 1e-8; what remains is a learned field capacity twice the catchment's, a response to doubled rain above the rain added, a runoff depth that changes with the area it is told, and a third more runoff when snow falls as rain |
-| `reference_bucket` | exact | conserves water exactly by construction | must pass every probe that can ask it anything; INCOMPLETE on the two energy probes, which need fluxes it does not report |
-| [`flex_lumped`](models/flex_lumped) | physical | lumped FLEX/HBV: interception, beta-partitioned unsaturated store, fast and slow reservoirs, triangular lag | must pass every probe that can ask it anything; **PASS**, 15 of 17, INCOMPLETE on the two energy probes |
-| [`flex_topo`](models/flex_topo) | physical | FLEX-Topo: plateau, hillslope and wetland units on real Wark fractions sharing one groundwater store | must pass every probe that can ask it anything; **PASS**, 15 of 17, INCOMPLETE on the two energy probes |
-| [`sacsma_snow17`](models/sacsma_snow17) | physical | the NWS's SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it | must pass every probe that can ask it anything; **PASS**, 15 of 17, INCOMPLETE on the two energy probes |
-| `reference_coupled` | exact | the bucket with snow sublimation and a surface energy budget: every kilogram converted at the latent heat of the phase it actually underwent | must pass every criterion of `energy/latent-heat-et-consistency` |
+| [`google_flood_forecast`](models/google_flood_forecast) | submitted | The mean-embedding forecast LSTM behind Google Flood Hub, at the published weights. Predicts discharge and nothing else. | **FAIL (INCOMPLETE)**, 5 of 18 probes passed. Runoff-only, so seven probes cannot ask it anything; of the eleven that ask on runoff alone it passes the runoff bounds, memory, area, causality and steady state, and fails step, extreme rain, phase, warming, dry-down, and a 0.18 mm/day dip after an added storm |
+| [`dhbv2`](models/dhbv2) | submitted | δHBV 2.0, the MHPI group's differentiable HBV: neural networks write the parameters of a bucket model that reports its stores and its evaporation. | **FAIL (VIOLATION)**, 11 of 18 probes passed. Its learned regional-groundwater term, declared as `gwex`, closes the budget to 1e-8; what remains is a learned field capacity twice the catchment's, a response to doubled rain above the rain added, a runoff depth that changes with the area it is told, and a third more runoff when snow falls as rain |
+| `reference_bucket` | exact | conserves water exactly by construction | must pass every probe that can ask it anything; INCOMPLETE on the three energy-flux probes, which need fluxes it does not report |
+| [`flex_lumped`](models/flex_lumped) | physical | lumped FLEX/HBV: interception, beta-partitioned unsaturated store, fast and slow reservoirs, triangular lag | must pass every probe that can ask it anything; **PASS**, 15 of 18, INCOMPLETE on the three energy-flux probes |
+| [`flex_topo`](models/flex_topo) | physical | FLEX-Topo: plateau, hillslope and wetland units on real Wark fractions sharing one groundwater store | must pass every probe that can ask it anything; **PASS**, 15 of 18, INCOMPLETE on the three energy-flux probes |
+| [`sacsma_snow17`](models/sacsma_snow17) | physical | the NWS's SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it | must pass every probe that can ask it anything; **PASS**, 15 of 18, INCOMPLETE on the three energy-flux probes |
+| `reference_coupled` | exact | the bucket with snow sublimation and a surface energy budget: every kilogram converted at the latent heat of the phase it actually underwent | must pass every criterion of the three energy-flux probes; supports daily and hourly steps |
 | `reference_two_head` | broken | a water head and an energy head that never meet: both budgets close to 1e-15 and the latent heat implies an evaporation it never reported | caught by `flux_identity` |
 | `reference_constant_lambda` | broken | coherent, but converts every kilogram at the same latent heat of vaporisation | caught by `flux_identity` |
 | `reference_sublimation_blind` | broken | coherent for liquid water, but converts snow sublimation at the latent heat of vaporisation instead of sublimation | caught by `flux_identity` |
 | `reference_ground_dodge` | broken | coherent, both budgets close, and the sensible flux never reads the soil: when the soil dries the ground flux absorbs the whole shift | caught by `partition_shift` |
+| `reference_diurnal_bias` | broken | shifts sensible heat so the energy residual is +20 W/m2 by day and -20 W/m2 by night; the full-record residual cancels | caught by `energy_closure_by_phase` |
 | `reference_energy_leak` | broken | discards 15% of net radiation; the energy counterpart of `reference_leaky` | caught by `energy_closure` |
 | `reference_leaky` | broken | hides a silent 15% sink | caught by `closure` |
 | `reference_cheater` | broken | solves for storage as whatever balances the budget | caught by `state_bounds` |
@@ -304,7 +307,7 @@ where that conversation happens, before and alongside the issues.
 
 ## Status
 
-Suite `0.1.0`, pre-release. Seventeen probes, thirteen mass, three energy, one momentum, synthetic track only. More
+Suite `0.1.0`, pre-release. Eighteen probes, thirteen mass, four energy, one momentum, synthetic track only. More
 energy and momentum probes, and the real-data track, are next. The harness runs paired cases and
 scores labelled regimes, so the generalisation probes on the roadmap —
 extrapolation in space and time, counterfactual response, invariance — are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -184,12 +184,14 @@ the normalization used to compare outputs.
 ### `energy/pet-consistency` &middot; **merged**
 Evaporation follows demand when the model's own soil is wettest and water when it is driest; no energy flux needed.
 
-### `energy/surface-energy-closure` &middot; starter &middot; **unclaimed**
-Net radiation minus sensible minus latent minus ground heat flux, minus the
-change in stored energy.
-*Note:* the denominator is accumulated |Rn|, which crosses zero every night,
-so this probe **must** set an absolute floor as well as the 5 percent rule.
-The canonical energy probe and the natural first one.
+### `energy/surface-energy-closure` &middot; **merged**
+Hourly net radiation minus sensible, latent and ground heat flux must close
+within each contiguous day or night, without errors cancelling across hours
+or phases. The mean absolute residual is bounded by the larger of 5 percent
+of mean absolute net radiation and 2 W/m2. The boundary is a snow-free bare
+surface with negligible heat capacity; ground heat flux is measured at that
+surface, so no separate soil-storage term is subtracted.
+Contributed by Han Wang ([@cehw](https://github.com/cehw)).
 
 ### `energy/snowpack-cold-content` &middot; hard &middot; **unclaimed**
 The full snowpack energy budget including cold content and phase change. Melt

--- a/docs/writing-a-probe.md
+++ b/docs/writing-a-probe.md
@@ -111,6 +111,7 @@ Every one is binary.
 | `antecedent_monotonicity` | the same storm after more rain runs off more, and no more than the extra rain | paired runs |
 | `phase_invariance` | the same water as rain instead of snow leaves the integrated volumes within a share of the rain | paired runs |
 | `demand_consistency` | evaporation reaches demand when the model's own soil is wettest, never exceeds it, and falls when driest | one run |
+| `energy_closure_by_phase` | the mean absolute surface-energy residual in each contiguous day or night stays within the larger of the relative radiation tolerance and the absolute flux floor | one run, contiguous day/night blocks |
 | `routing_conservation` | the channel store is non-negative and never exceeds `max_lag_days` of the largest recent runoff | one run |
 
 Picking a denominator for `closure` and `regime_transfer`:
@@ -255,6 +256,7 @@ The reference models available today:
 | `reference_sublimation_blind` | converts snow sublimation at the latent heat of vaporisation instead of sublimation | `flux_identity` |
 | `reference_energy_leak` | discards 15% of net radiation | `energy_closure` |
 | `reference_ground_dodge` | coherent and closed, but its sensible flux never reads the soil, so the ground flux absorbs a drydown's whole shift | `partition_shift` |
+| `reference_diurnal_bias` | shifts sensible heat to leave opposite day and night energy residuals that cancel over the full record | `energy_closure_by_phase` |
 
 If your probe needs a broken model that does not exist yet, add it under
 `models/` alongside the probe. A criterion with nothing that trips it is

--- a/models/reference_coupled/model.yaml
+++ b/models/reference_coupled/model.yaml
@@ -1,5 +1,5 @@
 name: reference_coupled
-version: "1.0.0"
+version: "1.1.0"
 description: >
   The bucket of reference_bucket with snow sublimation and a surface energy
   budget. Every kilogram of water that leaves the surface is converted to
@@ -13,7 +13,7 @@ authors: ["HydroTuring maintainers"]
 license: PolyForm-Noncommercial-1.0.0
 runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
-timestep: [PT1D]
+timestep: [PT1D, PT1H]
 emits:
   fluxes: [pr, evspsbl, mrro, sbl, hfls, hfss, hfg]
   states: [mrso, snw, canopy, channel]

--- a/models/reference_diurnal_bias/ht_adapter.py
+++ b/models/reference_diurnal_bias/ht_adapter.py
@@ -2,19 +2,20 @@
 """HydroTuring adapter. Standard library only, to show that the /io contract
 needs no scientific Python stack and could be written in any language.
 
-The exact model for the coherence probe: one evaporation, reported twice.
+A correct water/energy account with equal and opposite hourly sensible-heat errors.
+Only H changes: the cumulative residual cancels over complete 24-hour cycles.
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
+from datetime import datetime
 import json
 import sys
 from pathlib import Path
 
-MODE = "coupled"
-MODEL = {"name": "reference_coupled", "version": "1.1.0"}
+MODEL = {"name": "reference_diurnal_bias", "version": "1.0.0"}
 
 COLUMNS = [
     "time", "pr", "evspsbl", "mrro", "sbl", "hfls", "hfss", "hfg",
@@ -28,10 +29,7 @@ GROUND_SHARE = 0.10  # share of net radiation conducted into the ground
 # Latent heat of vaporisation as A + B*T (T in degC) and of fusion, J kg-1.
 LAMBDA_A, LAMBDA_B = 2.501e6, -2361.0
 LAMBDA_F = 3.337e5
-LAMBDA_CONST = 2.45e6  # the constant a careless model would use
-CLIMATOLOGICAL_EF = 0.65  # evaporative fraction of a model whose heads never meet
-CLIMATOLOGICAL_H_SHARE = 0.25  # sensible share of a model whose H never reads the soil
-ENERGY_LEAK = 0.15
+DIURNAL_BIAS_W_M2 = 20.0
 SECONDS_PER_DAY = 86400.0
 
 TIMESTEP_DAYS = {
@@ -44,44 +42,13 @@ TIMESTEP_DAYS = {
 
 
 def partition_energy(rn, tas, liquid_mm, sublimated_mm, dt_days):
-    """Turn the water that left the surface into the energy that carried it.
-
-    `reference_coupled` is exact: every kilogram is converted at the latent
-    heat of the phase change it actually underwent, and the sensible flux is
-    what net radiation has left once the latent and ground fluxes are taken.
-    Solving for H that way is the physical statement that the surface has no
-    other place to put the energy, and it is why this model closes the energy
-    budget by construction, exactly as `reference_bucket` closes the water
-    budget by construction. The discrimination lives in the other four.
-    """
+    """The exact coupled account before the deliberate temporal bias in H."""
     seconds = dt_days * SECONDS_PER_DAY
     lam_v = LAMBDA_A + LAMBDA_B * tas
     lam_s = LAMBDA_A + LAMBDA_F
     ground = GROUND_SHARE * rn
-
-    if MODE == "constant_lambda":
-        latent = LAMBDA_CONST * (liquid_mm + sublimated_mm) / seconds
-    elif MODE == "sublimation_blind":
-        latent = lam_v * (liquid_mm + sublimated_mm) / seconds
-    elif MODE == "two_head":
-        # An energy head that never reads the water head: the partition is a
-        # climatological evaporative fraction of the available energy, and it
-        # has no idea how much water actually left.
-        latent = CLIMATOLOGICAL_EF * (rn - ground)
-    else:
-        latent = (lam_v * liquid_mm + lam_s * sublimated_mm) / seconds
-
-    if MODE == "ground_dodge":
-        # A sensible heat flux that is a fixed share of net radiation and never
-        # reads the soil, with the ground flux left to absorb whatever the
-        # latent flux gives up. Coherent, and both budgets close.
-        sensible = CLIMATOLOGICAL_H_SHARE * rn
-        return latent, sensible, rn - latent - sensible
-
-    sensible = rn - ground - latent
-    if MODE == "energy_leak":
-        sensible -= ENERGY_LEAK * rn
-    return latent, sensible, ground
+    latent = (lam_v * liquid_mm + lam_s * sublimated_mm) / seconds
+    return latent, rn - ground - latent, ground
 
 
 def simulate(forcing, static, dt_days=1.0):
@@ -140,6 +107,12 @@ def simulate(forcing, static, dt_days=1.0):
 
         liquid = canopy_evap + soil_evap
         latent, sensible, ground = partition_energy(rn, tas, liquid, sublimation, dt_days)
+
+        # Timestamps are interval starts in this probe's local-solar clock.
+        # Use only the present input, never hidden phase labels or the run horizon.
+        hour = datetime.fromisoformat(str(step["time"])).hour
+        residual = DIURNAL_BIAS_W_M2 if 6 <= hour < 18 else -DIURNAL_BIAS_W_M2
+        sensible -= residual
 
         rows.append({
             "time": step["time"],

--- a/models/reference_diurnal_bias/model.yaml
+++ b/models/reference_diurnal_bias/model.yaml
@@ -1,0 +1,20 @@
+name: reference_diurnal_bias
+version: "1.0.0"
+description: >
+  The coupled reference's water and energy account with only sensible heat
+  biased: the residual is +20 W m-2 from 06:00 to 18:00 local-solar time,
+  and -20 W m-2 otherwise. Complete day/night cycles cancel in a signed
+  cumulative energy budget while every phase has a large absolute error.
+  This is the declared negative control for energy/surface-energy-closure.
+authors: ["Han Wang"]
+license: PolyForm-Noncommercial-1.0.0
+runner: subprocess
+entrypoint: ["python3", "ht_adapter.py"]
+timestep: [PT1H]
+emits:
+  fluxes: [pr, evspsbl, mrro, sbl, hfls, hfss, hfg]
+  states: [mrso, snw, canopy, channel]
+needs_forcing: [pr, tas, pet, rn]
+supports:
+  perturbation: true
+resources: {cpu: 1, memory_gb: 1, gpu: false}

--- a/models/result.csv
+++ b/models/result.csv
@@ -191,3 +191,8 @@ run_date,model,version,suite_version,runner,probe,verdict,reason,window,seeds,de
 2026-09-11,sacsma_snow17,1.0.0,0.1.0,subprocess,mass/time-origin-invariance,PASS,OK,full record,1264165719 1771117833 130586300,residual 0.000% of driver
 2026-09-11,google_flood_forecast,0.1.0-828dfc5,0.1.0,docker,mass/time-origin-invariance,FAIL,INCOMPLETE,not run,,"does not report pr, evspsbl, mrso, snw, canopy"
 2026-09-11,dhbv2,0.5.4-hbv2ep100.3,0.1.0,docker,mass/time-origin-invariance,PASS,OK,full record,1264165719 1771117833 130586300,residual 0.000% of driver
+2026-09-10,google_flood_forecast,0.1.0-828dfc5,0.1.0,docker,energy/surface-energy-closure,FAIL,INCOMPLETE,not run,,"does not report hfls, hfss, hfg; model timestep PT1D does not cover the probe's PT1H"
+2026-09-10,dhbv2,0.5.4-hbv2ep100.3,0.1.0,docker,energy/surface-energy-closure,FAIL,INCOMPLETE,not run,,"does not report hfls, hfss, hfg; model timestep PT1D does not cover the probe's PT1H"
+2026-09-10,flex_lumped,1.0.0,0.1.0,subprocess,energy/surface-energy-closure,FAIL,INCOMPLETE,not run,,"does not report hfls, hfss, hfg"
+2026-09-10,flex_topo,1.0.0,0.1.0,subprocess,energy/surface-energy-closure,FAIL,INCOMPLETE,not run,,"does not report hfls, hfss, hfg"
+2026-09-10,sacsma_snow17,1.0.0,0.1.0,subprocess,energy/surface-energy-closure,FAIL,INCOMPLETE,not run,,"does not report hfls, hfss, hfg"

--- a/probes/energy/surface-energy-closure/README.md
+++ b/probes/energy/surface-energy-closure/README.md
@@ -35,6 +35,8 @@ existing energy-closure engineering conventions. They are starting values,
 not observationally calibrated tolerances. The denominator uses absolute
 net radiation; neither signed cancellation nor division by near-zero Rn is
 involved. The floor provides a finite allowance under weak radiation.
+In this generator, each night's |Rn| is 25-40 W m-2, so every night block
+uses the 2 W m-2 floor; the daily seeded cooling varies between nights.
 
 ### The budget boundary
 
@@ -44,12 +46,28 @@ storage, or lateral energy transport. Evaporation or condensation is carried
 by LE. G is at the **actual soil surface**. Subsurface heat storage lies
 below that boundary and must not also be subtracted from this skin budget.
 
-A model with G at a deeper soil boundary, or with finite skin/canopy heat
-storage, needs a matching boundary or explicit storage accounting before
-this residual can judge it. Output names and `PT1H` support alone cannot
-establish this. The harness checks those declarations; adapter documentation
-and review must establish the physical boundary. A failure should only be
-interpreted as a conservation violation for a compatible boundary.
+An adapter whose model reports a plate-depth or deeper-boundary flux must
+map it to the surface using the heat stored in the layer above that depth:
+
+```
+G_surface = G_depth + (E_above_end - E_above_start) / dt
+```
+
+Both G values are interval means, positive downward; `E_above` is heat
+storage per unit area in J m-2, and `dt` is in seconds. All terms must refer
+to the same area, control volume and time interval, with no other energy
+sources or sinks in that layer. The correction must use the model's actual
+storage, not a fabricated value or the surface-budget residual. Report the
+corrected `G_surface` as `hfg`; do not subtract that storage a second time.
+
+A model with finite skin/canopy heat storage, or without the terms needed
+for this mapping, cannot be judged by this zero-capacity boundary without
+further accounting. Output names and `PT1H` support alone cannot establish
+compatibility. The harness checks those declarations; adapter documentation
+and review must establish the physical boundary. A reported residual can
+come from a conservation error or an uncorrected deeper-boundary flux. Only
+with the boundary mapping established is `VIOLATION` evidence of failure to
+close this surface budget.
 
 ## The case
 
@@ -126,3 +144,7 @@ within-block cancellation, spinup exclusion, generator reproducibility,
 complete scored phases, annotation stripping, and the minimum model window.
 These checks establish the implemented accounting test, not a validation of
 an AI or a comprehensive land-surface model.
+The plate-depth regression additionally checks a 5 cm layer with prescribed
+0.5 K and 2 K diurnal temperature amplitudes: the uncorrected flux fails,
+while adding that layer's known storage change restores surface closure.
+This verifies the boundary mapping, not a realistic soil thermal response.

--- a/probes/energy/surface-energy-closure/README.md
+++ b/probes/energy/surface-energy-closure/README.md
@@ -1,0 +1,128 @@
+# energy/surface-energy-closure
+
+## What it asserts
+
+For interval-mean fluxes over the same hourly interval, the surface residual is
+
+```
+r_i = Rn_i - H_i - LE_i - G_i                         [W m-2]
+```
+
+`Rn` (`rn`) is positive into the surface; sensible heat `H` (`hfss`) and
+latent heat `LE` (`hfls`) are positive away from it; ground heat `G` (`hfg`)
+is positive from the surface into the ground. Negative H and LE are allowed,
+including at night. No rule requires nighttime evaporation to vanish.
+
+For each **contiguous** solar daytime or nighttime block b, define
+
+```
+T_b = sum_i(dt_i)
+E_b = sum_i(abs(r_i)  * dt_i) / T_b                  [W m-2]
+D_b = sum_i(abs(Rn_i) * dt_i) / T_b                  [W m-2]
+A_b = max(0.05 * D_b, 2 W m-2)
+```
+
+Every block must satisfy `E_b <= A_b`. At this probe's fixed hourly step the
+duration-weighted means equal ordinary means. Absolute residuals are taken
+**before** summing: opposite errors cannot cancel within a block, and a good
+day cannot compensate for a bad night. Repeated labels denote separate
+blocks, not one average over all daytime rows and another over all nights.
+The criterion reports block duration, mean absolute residual, allowance,
+failed block count and the worst block.
+
+The 5% relative allowance and 2 W m-2 absolute floor carry forward the
+existing energy-closure engineering conventions. They are starting values,
+not observationally calibrated tolerances. The denominator uses absolute
+net radiation; neither signed cancellation nor division by near-zero Rn is
+involved. The floor provides a finite allowance under weak radiation.
+
+### The budget boundary
+
+The case is a homogeneous, snow-free bare surface with a **zero-capacity
+skin**. It has no canopy, snow/ice melting or freezing, unreported phase-change
+storage, or lateral energy transport. Evaporation or condensation is carried
+by LE. G is at the **actual soil surface**. Subsurface heat storage lies
+below that boundary and must not also be subtracted from this skin budget.
+
+A model with G at a deeper soil boundary, or with finite skin/canopy heat
+storage, needs a matching boundary or explicit storage accounting before
+this residual can judge it. Output names and `PT1H` support alone cannot
+establish this. The harness checks those declarations; adapter documentation
+and review must establish the physical boundary. A failure should only be
+interpreted as a conservation violation for a compatible boundary.
+
+## The case
+
+`generate.py` returns 384 hourly rows: two spinup days followed by 14 scored
+days. The record starts at local-solar 06:00, leaving exactly 28 complete
+12-hour scored blocks. A timestamp labels the start of `[time, time + 1 h)`.
+Daytime is 06:00-18:00 and nighttime is 18:00-06:00 in this idealised solar
+clock. `_regime` follows that clock, not the sign of Rn. The harness retains
+annotations for scoring and strips them before sending forcing to a model.
+
+Absorbed shortwave follows a 12-hour positive sine, integrated analytically
+over each hour. Its daily amplitude is 420-540 W m-2 and hourly seeded cloud
+attenuation is 0.45-1.0. Subtracting 25-40 W m-2 of daily longwave cooling
+gives the imposed net radiation. Cloud attenuation and cooling are constant
+within each interval, so Rn is an interval mean. Nighttime cooling and the
+daylight shoulders include weak net radiation. Rn is a supplied boundary
+flux, not a prediction based on surface radiative temperature.
+
+Air stays warm (16-28 degC), canopy capacity is zero, and the water inputs
+give the existing accounting reference modest evaporative demand and
+occasional rainfall. Water fluxes remain rates in mm/day at every hour.
+The reference starts with half of its 180 mm soil capacity. These inputs
+support a warm bare-surface accounting case; no water or temperature states
+are required from the model being tested.
+
+`min_window_days: 14` prevents the default seven-day hourly evaluation
+window from truncating the scored cycles. The generator uses the actual
+`generate(seed)` contract; its row count is derived from the period, spinup
+and hourly resolution, and the harness checks it against `probe.yaml`.
+
+## Why this criterion
+
+The existing `energy_closure` is unchanged. Its signed cumulative residual
+can be zero while hourly residuals are large. Starting from an exact
+accounting solution, `reference_diurnal_bias` changes H alone so the residual
+is +20 W m-2 during the day and -20 W m-2 at night. The complete record
+closes cumulatively, but every block fails `energy_closure_by_phase`. The
+negative reference reads the current solar timestamp, never hidden phase
+annotations, the evaluation horizon or future rows.
+
+Only the new criterion is needed here: this probe tests that temporal
+accounting property. The earlier energy probes continue to test latent-heat
+identity and seasonal repartitioning. Unit regressions retain the old
+criterion's passing result on cancelling errors, including alternating
+hourly errors inside each phase, to show the specific difference.
+
+### What can still pass
+
+`reference_coupled` diagnoses H as `Rn - LE - G` and closes by construction.
+It is an accounting positive control, not an independent thermal-inertia
+model. A model that diagnoses a remainder, or makes equal and opposite
+errors in simultaneous components, can still pass this probe. Passing does
+not establish realistic turbulent exchange, component accuracy, radiative
+temperature, soil heat storage or physical understanding. Heat
+storage-temperature consistency is a separate question.
+
+## Reproducing a failure
+
+The directory was created with HydroTuring's `init-probe` scaffolding and
+filled in for the scope accepted in
+[proposal #15](https://github.com/Flood-Lab/HydroTuring/issues/15).
+
+```bash
+ht validate
+ht gate --probe energy/surface-energy-closure
+ht run --model reference_coupled --probe energy/surface-energy-closure --seed 0
+ht run --model reference_diurnal_bias --probe energy/surface-energy-closure --seed 0
+pytest -q tests/test_surface_energy_closure.py tests/test_surface_energy_probe.py
+```
+
+The first model must pass; the second must fail specifically on
+`energy_closure_by_phase`. The tests also check weak-radiation allowances,
+within-block cancellation, spinup exclusion, generator reproducibility,
+complete scored phases, annotation stripping, and the minimum model window.
+These checks establish the implemented accounting test, not a validation of
+an AI or a comprehensive land-surface model.

--- a/probes/energy/surface-energy-closure/generate.py
+++ b/probes/energy/surface-energy-closure/generate.py
@@ -1,0 +1,83 @@
+"""Seeded hourly forcing for a warm, snow-free, bare surface energy budget.
+
+Timestamps are interval starts in local solar time. The imposed net radiation
+is an interval mean, not a radiative-temperature prediction. The harness
+retains the day/night annotation for scoring and strips it before staging.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+PERIOD_DAYS = 14
+SPINUP_DAYS = 2
+STEPS_PER_DAY = 24
+N_STEPS = (PERIOD_DAYS + SPINUP_DAYS) * STEPS_PER_DAY
+
+STATIC = {
+    "area_km2": 250.0,
+    "soil_capacity_mm": 180.0,
+    "canopy_capacity_mm": 0.0,
+    "degree_day_factor_mm_per_C_day": 3.2,
+    "baseflow_coefficient": 0.006,
+    "snow_threshold_degC": 0.0,
+    "latitude_deg": 0.0,
+}
+
+
+def generate(seed: int) -> tuple[pd.DataFrame, dict]:
+    rng = np.random.default_rng(seed)
+    time = pd.date_range("2000-03-20T06:00:00", periods=N_STEPS, freq="h")
+    hour = time.hour.to_numpy()
+    daytime = (hour >= 6) & (hour < 18)
+    solar_day = np.arange(N_STEPS) // STEPS_PER_DAY
+    n_days = PERIOD_DAYS + SPINUP_DAYS
+
+    # Exact hourly mean of the positive sine between sunrise at 06:00 and
+    # sunset at 18:00: integral sin(omega * (h - 6)) dh over [h, h + 1).
+    # Cloud attenuation and longwave cooling are constant within each hour,
+    # so their combination below is also an interval-mean forcing.
+    omega = np.pi / 12.0
+    daylight = np.where(
+        daytime,
+        (np.cos(omega * (hour - 6)) - np.cos(omega * (hour - 5))) / omega,
+        0.0,
+    )
+    peak_shortwave = rng.uniform(420.0, 540.0, n_days)[solar_day]
+    cloud = rng.uniform(0.45, 1.0, N_STEPS)
+    longwave_cooling = rng.uniform(25.0, 40.0, n_days)[solar_day]
+    rn = peak_shortwave * cloud * daylight - longwave_cooling
+
+    # Warm air excludes snow and freezing. A daily weather offset and a
+    # smooth diurnal cycle are prescribed interval means; they are not a
+    # surface temperature or an energy storage state.
+    weather = rng.uniform(-2.0, 2.0, n_days)[solar_day]
+    midpoint = hour + 0.5
+    tas = 22.0 + weather + 4.0 * np.cos(2 * np.pi * (midpoint - 14.0) / 24.0)
+
+    # Water-side inputs for the accounting reference, in mm/day even at an
+    # hourly step. Small nonzero nighttime demand is allowed: this probe
+    # imposes no sign restriction on latent or sensible heat.
+    pet = 0.12 + 3.2 * daylight * cloud
+    wet = rng.random(N_STEPS) < 0.025
+    pr = np.where(wet, rng.uniform(12.0, 48.0, N_STEPS), 0.0)
+
+    forcing = pd.DataFrame(
+        {
+            "time": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "pr": np.round(pr, 6),
+            "tas": np.round(tas, 6),
+            "pet": np.round(pet, 6),
+            "rn": np.round(rn, 6),
+            # Phase follows the solar clock, never the sign of net radiation.
+            "_regime": np.where(daytime, "day", "night"),
+        }
+    )
+    return forcing, dict(STATIC)
+
+
+if __name__ == "__main__":
+    frame, _ = generate(20260910)
+    print(f"{len(frame)} hourly rows: {SPINUP_DAYS} spinup + {PERIOD_DAYS} scored days")
+    print(f"Net radiation: {frame['rn'].min():.1f} to {frame['rn'].max():.1f} W/m2")

--- a/probes/energy/surface-energy-closure/probe.yaml
+++ b/probes/energy/surface-energy-closure/probe.yaml
@@ -6,6 +6,10 @@ version: 1
 
 authors:
   - name: Han Wang
+    affiliation: >-
+      Department of Civil and Environmental Engineering,
+      The Hong Kong University of Science and Technology, Hong Kong, China
+    orcid: "0000-0001-9771-1324"
     github: cehw
 
 description: >

--- a/probes/energy/surface-energy-closure/probe.yaml
+++ b/probes/energy/surface-energy-closure/probe.yaml
@@ -1,0 +1,57 @@
+id: energy/surface-energy-closure
+title: Hourly surface budgets cannot hide cancelling energy errors
+law: energy
+track: synthetic
+version: 1
+
+authors:
+  - name: Han Wang
+    github: cehw
+
+description: >
+  The energy budget of a homogeneous, snow-free bare surface with a
+  zero-capacity skin must close within each contiguous solar day or night.
+  Absolute hourly residuals are averaged before comparing with the allowance,
+  so opposite errors cannot cancel across phases or within one phase. Net
+  radiation is prescribed; ground heat is evaluated at the actual soil
+  surface. The case excludes canopy heat storage, unreported phase-change
+  storage and lateral energy transport. Passing establishes temporal budget
+  consistency, not a realistic partition or a thermal-inertia response.
+
+requires:
+  fluxes: [hfls, hfss, hfg]
+  states: []
+
+case:
+  generator: generate.py
+  n_seeds: 5
+  timestep: PT1H
+  period_days: 14
+  spinup_days: 2
+  # The usual hourly model window is seven days. Keep all 28 complete phases.
+  min_window_days: 14
+  max_output_mb: 2.0
+  max_runtime_s: 60
+
+criteria:
+  - energy_closure_by_phase:
+      driver: rn
+      sinks: [hfls, hfss, hfg]
+      # Compare mean(abs(residual)) with 5% of mean(abs(Rn)) in each block.
+      # A 2 W/m2 allowance handles weak radiation; both values are engineering
+      # conventions carried from energy_closure, not observational calibration.
+      threshold: 0.05
+      floor: 2.0
+      segment_column: _regime
+
+baselines:
+  must_pass: [reference_coupled]
+  must_fail:
+    reference_diurnal_bias: energy_closure_by_phase
+
+provenance: >
+  Synthetic, generated at run time from the recorded seed. Hourly cloud
+  attenuation, daily shortwave amplitude and longwave cooling vary by seed.
+  Timestamps are local-solar interval starts. Hidden day/night annotations
+  are stripped before staging model inputs. Proposal and agreed scope:
+  https://github.com/Flood-Lab/HydroTuring/issues/15.

--- a/site/index.html
+++ b/site/index.html
@@ -309,8 +309,10 @@ a:focus-visible,button:focus-visible{outline:2px solid var(--accent); outline-of
       <text x="396" y="187" class="probe" data-i18n="infra.probe.latent">latent heat</text>
       <circle cx="388" cy="197.5" r="2.4" fill="var(--pass)"/>
       <text x="396" y="201" class="probe" data-i18n="infra.probe.partition">partition</text>
-      <rect x="384" y="214" width="68" height="40" rx="5" fill="none" stroke="var(--line-strong)" stroke-dasharray="3 3"/>
-      <text x="418" y="238" class="note" data-i18n="infra.wanted" text-anchor="middle">probes wanted</text>
+      <circle cx="388" cy="211.5" r="2.4" fill="var(--pass)"/>
+      <text x="396" y="215" class="probe" data-i18n="infra.probe.diurnal">day / night</text>
+      <rect x="384" y="228" width="68" height="40" rx="5" fill="none" stroke="var(--line-strong)" stroke-dasharray="3 3"/>
+      <text x="418" y="252" class="note" data-i18n="infra.wanted" text-anchor="middle">probes wanted</text>
       <rect x="472" y="100" width="92" height="250" rx="6" fill="var(--surface-2)"/>
       <text x="518" y="121" class="pillar" data-i18n="infra.momentum" text-anchor="middle">MOMENTUM</text>
       <text x="518" y="138" class="note" data-i18n="infra.momentum.s1" text-anchor="middle">routing conserves</text>
@@ -614,6 +616,7 @@ en: {
   "infra.probe.pet":"PET demand",
   "infra.probe.latent":"latent heat",
   "infra.probe.partition":"partition",
+  "infra.probe.diurnal":"day / night",
   "infra.probe.routing":"routing",
   "infra.flow":"seed → case → run → one bit",
   "infra.s1a":"seeded",
@@ -657,11 +660,11 @@ en: {
   "models.th5":"Verdict",
   "models.intro":"<p>Every model that has been run against the suite. A submitted model is evaluated in an isolated container on a flood-event window of each probe's generated record. A physical model is one the acceptance gate requires every probe to pass; it is evaluated the same way, and a probe that fails one is examined before the model is.</p>",
   "models.legend":"<p>Every evaluation is appended to <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>, with the probe, the window, the seeds and the worst criterion. The verdict is one bit and its reason; the numbers under it are in the archive and in each model's README. To submit a model, open a <a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">model submission</a>.</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>submitted</td><td>Google Flood Hub's mean-embedding forecast LSTM, through OpenHydroNet with the published weights. Discharge only.</td><td>5 / 17</td><td><span class="tag incomplete">FAIL (INCOMPLETE)</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>submitted</td><td>δHBV 2.0, the MHPI differentiable HBV: networks write the parameters of a bucket model that reports its stores, its evaporation and, declared, its regional groundwater exchange.</td><td>11 / 17</td><td><span class="tag violation">FAIL (VIOLATION)</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>physical</td><td>Lumped FLEX/HBV from chrimerss/HydrologicModels: interception, beta-partitioned soil, fast and slow reservoirs, a lag.</td><td>15 / 17</td><td><span class="tag merged">PASS</span></td></tr>
-<tr><td class="mono">flex_topo</td><td>physical</td><td>FLEX-Topo: plateau, hillslope and wetland units on the Wark catchment's real fractions, sharing one groundwater store.</td><td>15 / 17</td><td><span class="tag merged">PASS</span></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>physical</td><td>The NWS operational SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it.</td><td>15 / 17</td><td><span class="tag merged">PASS</span></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>submitted</td><td>Google Flood Hub's mean-embedding forecast LSTM, through OpenHydroNet with the published weights. Discharge only.</td><td>5 / 18</td><td><span class="tag incomplete">FAIL (INCOMPLETE)</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>submitted</td><td>δHBV 2.0, the MHPI differentiable HBV: networks write the parameters of a bucket model that reports its stores, its evaporation and, declared, its regional groundwater exchange.</td><td>11 / 18</td><td><span class="tag violation">FAIL (VIOLATION)</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>physical</td><td>Lumped FLEX/HBV from chrimerss/HydrologicModels: interception, beta-partitioned soil, fast and slow reservoirs, a lag.</td><td>15 / 18</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>physical</td><td>FLEX-Topo: plateau, hillslope and wetland units on the Wark catchment's real fractions, sharing one groundwater store.</td><td>15 / 18</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>physical</td><td>The NWS operational SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it.</td><td>15 / 18</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
 `,
   "probes.h":"The probes",
   "probes.intro":"<p>Every probe in the suite, and every one the roadmap is waiting for. A merged probe is in the repository and passes the acceptance gate against the reference models. A wanted probe is named, unclaimed, and yours to take.</p>",
@@ -686,6 +689,7 @@ en: {
 <tr><td class="mono">energy/pet-consistency</td><td>energy</td><td>Evaporation reaches demand when the model's own soil is wettest, never exceeds it, and falls when driest.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>energy</td><td>The evaporation a model reports as water and the one implied by its latent heat: are they the same evaporation?</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>energy</td><td>One summer without rain under radiation that did not change: the latent heat a drying surface gives up has to warm the air.</td><td><span class="tag merged">merged</span></td></tr>
+<tr><td class="mono">energy/surface-energy-closure</td><td>energy</td><td>Does each day and night close its hourly surface energy budget, without opposite errors cancelling?</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">momentum/routing-conservation</td><td>momentum</td><td>The channel store is never negative and never holds more than its hydrograph can.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">coupled/snowmelt-energy-water</td><td>coupled</td><td>Melt in the water budget must match the energy spent melting.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/snowpack-mass-closure</td><td>mass</td><td>Snowfall minus melt minus sublimation minus the change in snow water.</td><td><span class="tag wanted">wanted</span></td></tr>
@@ -695,7 +699,6 @@ en: {
 <tr><td class="mono">mass/extreme-event-closure</td><td>mass</td><td>Closure through a storm outside anything earlier in the record.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>mass</td><td>Closure on catchments outside the range models are fitted to.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/precipitation-counterfactual</td><td>mass</td><td>Add water to the same case and ask where it went.</td><td><span class="tag wanted">wanted</span></td></tr>
-<tr><td class="mono">energy/surface-energy-closure</td><td>energy</td><td>Net radiation minus sensible, latent and ground heat flux, minus storage change.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>energy</td><td>The full snowpack energy budget, cold content and phase change included.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">energy/radiation-consistency</td><td>energy</td><td>Outgoing longwave must be consistent with the reported surface temperature.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">momentum/channel-routing-mass</td><td>momentum</td><td>Inflow minus outflow minus the change in channel storage, per reach.</td><td><span class="tag wanted">wanted</span></td></tr>
@@ -810,6 +813,7 @@ es: {
   "infra.probe.pet":"demanda",
   "infra.probe.latent":"calor latente",
   "infra.probe.partition":"partición",
+  "infra.probe.diurnal":"día / noche",
   "infra.probe.routing":"tránsito",
   "infra.flow":"semilla → caso → ejecución → un bit",
   "infra.s1a":"generador",
@@ -853,11 +857,11 @@ es: {
   "models.th5":"Veredicto",
   "models.intro":"<p>Todos los modelos que se han ejecutado contra la batería. Un modelo enviado se evalúa en un contenedor aislado sobre una ventana de crecida del registro generado de cada prueba. Un modelo físico es uno que la compuerta de aceptación exige que toda prueba supere; se evalúa igual, y una prueba que lo falla se examina antes que el modelo.</p>",
   "models.legend":"<p>Cada evaluación se añade a <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>, con la prueba, la ventana, las semillas y el peor criterio. El veredicto es un bit y su razón; los números están en el archivo y en el README de cada modelo. Para enviar un modelo, abre un <a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">envío de modelo</a>.</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>enviado</td><td>El LSTM de pronóstico de Google Flood Hub, vía OpenHydroNet con los pesos publicados. Solo caudal.</td><td>5 / 17</td><td><span class="tag incomplete">FALLA (INCOMPLETO)</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>enviado</td><td>δHBV 2.0, el HBV diferenciable de MHPI: redes que escriben los parámetros de un modelo de cubetas que reporta sus almacenes, su evaporación y, declarado, su intercambio regional de agua subterránea.</td><td>11 / 17</td><td><span class="tag violation">FALLA (VIOLACIÓN)</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>físico</td><td>FLEX/HBV agregado de chrimerss/HydrologicModels: intercepción, suelo con partición beta, embalses rápido y lento, un retardo.</td><td>15 / 17</td><td><span class="tag merged">PASA</span></td></tr>
-<tr><td class="mono">flex_topo</td><td>físico</td><td>FLEX-Topo: unidades de meseta, ladera y humedal con las fracciones reales de la cuenca Wark, un solo almacén subterráneo.</td><td>15 / 17</td><td><span class="tag merged">PASA</span></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>físico</td><td>El SAC-SMA operativo del NWS con Snow-17 y un hidrograma unitario gamma, portado del Fortran heredado y verificado contra él.</td><td>15 / 17</td><td><span class="tag merged">PASA</span></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>enviado</td><td>El LSTM de pronóstico de Google Flood Hub, vía OpenHydroNet con los pesos publicados. Solo caudal.</td><td>5 / 18</td><td><span class="tag incomplete">FALLA (INCOMPLETO)</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>enviado</td><td>δHBV 2.0, el HBV diferenciable de MHPI: redes que escriben los parámetros de un modelo de cubetas que reporta sus almacenes, su evaporación y, declarado, su intercambio regional de agua subterránea.</td><td>11 / 18</td><td><span class="tag violation">FALLA (VIOLACIÓN)</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>físico</td><td>FLEX/HBV agregado de chrimerss/HydrologicModels: intercepción, suelo con partición beta, embalses rápido y lento, un retardo.</td><td>15 / 18</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>físico</td><td>FLEX-Topo: unidades de meseta, ladera y humedal con las fracciones reales de la cuenca Wark, un solo almacén subterráneo.</td><td>15 / 18</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>físico</td><td>El SAC-SMA operativo del NWS con Snow-17 y un hidrograma unitario gamma, portado del Fortran heredado y verificado contra él.</td><td>15 / 18</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
 `,
   "probes.h":"Las pruebas",
   "probes.intro":"<p>Todas las pruebas de la batería, y todas las que la hoja de ruta espera. Una prueba integrada está en el repositorio y supera la compuerta de aceptación frente a los modelos de referencia. Una prueba que se busca tiene nombre, nadie la ha reclamado, y es tuya si la tomas.</p>",
@@ -882,6 +886,7 @@ es: {
 <tr><td class="mono">energy/pet-consistency</td><td>energía</td><td>La evaporación alcanza la demanda cuando el suelo del propio modelo está más húmedo, nunca la supera y baja cuando está más seco.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>energía</td><td>La evaporación que un modelo reporta como agua y la que implica su calor latente: ¿son la misma evaporación?</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>energía</td><td>Un verano sin lluvia bajo una radiación que no cambió: el calor latente que cede una superficie que se seca tiene que calentar el aire.</td><td><span class="tag merged">integrada</span></td></tr>
+<tr><td class="mono">energy/surface-energy-closure</td><td>energía</td><td>¿Cierra el balance energético horario en cada día y cada noche, sin que se cancelen errores opuestos?</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">momentum/routing-conservation</td><td>momento</td><td>El almacén del cauce nunca es negativo ni retiene más de lo que cabe en su hidrograma.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">coupled/snowmelt-energy-water</td><td>acoplada</td><td>El deshielo del balance hídrico debe coincidir con la energía gastada en fundir.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/snowpack-mass-closure</td><td>masa</td><td>Nevada menos deshielo menos sublimación menos el cambio de agua en la nieve.</td><td><span class="tag wanted">se busca</span></td></tr>
@@ -891,7 +896,6 @@ es: {
 <tr><td class="mono">mass/extreme-event-closure</td><td>masa</td><td>Cierre durante una tormenta fuera de todo lo anterior en el registro.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>masa</td><td>Cierre en cuencas fuera del rango al que se ajustan los modelos.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/precipitation-counterfactual</td><td>masa</td><td>Añadir agua al mismo caso y preguntar adónde fue.</td><td><span class="tag wanted">se busca</span></td></tr>
-<tr><td class="mono">energy/surface-energy-closure</td><td>energía</td><td>Radiación neta menos flujos sensible, latente y del suelo, menos el cambio de almacenamiento.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>energía</td><td>El balance energético completo del manto de nieve, con contenido frío y cambio de fase.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">energy/radiation-consistency</td><td>energía</td><td>La onda larga saliente debe ser coherente con la temperatura superficial reportada.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">momentum/channel-routing-mass</td><td>momento</td><td>Entrada menos salida menos el cambio de almacenamiento en el cauce, por tramo.</td><td><span class="tag wanted">se busca</span></td></tr>
@@ -1006,6 +1010,7 @@ zh: {
   "infra.probe.pet":"蒸散需求",
   "infra.probe.latent":"潜热一致",
   "infra.probe.partition":"能量分配",
+  "infra.probe.diurnal":"昼夜闭合",
   "infra.probe.routing":"汇流演算",
   "infra.flow":"种子 → 案例 → 运行 → 一位判定",
   "infra.s1a":"带种子的",
@@ -1049,11 +1054,11 @@ zh: {
   "models.th5":"结论",
   "models.intro":"<p>所有已在本套件上运行过的模型。提交模型在隔离容器中，于每个检验项生成记录的洪水事件窗口上评估。物理模型是验收闸门要求每个检验项都必须通过的模型，以同样方式评估；若某检验项未能通过物理模型，先检查检验项，再检查模型。</p>",
   "models.legend":"<p>每次评估都会追加到 <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>，记录检验项、窗口、种子与最差准则。结论是一个比特及其原因；其下的数字在归档和各模型的 README 中。提交模型请打开<a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">模型提交</a>。</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>提交模型</td><td>Google Flood Hub 的均值嵌入预报 LSTM，经 OpenHydroNet 以公开权重运行。仅输出流量。</td><td>5 / 17</td><td><span class="tag incomplete">未通过（信息不全）</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>提交模型</td><td>δHBV 2.0，MHPI 的可微 HBV：神经网络写出水桶模型的参数，模型报告蓄水、蒸发，并申报其区域地下水交换。</td><td>11 / 17</td><td><span class="tag violation">未通过（违反）</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>物理模型</td><td>来自 chrimerss/HydrologicModels 的集总 FLEX/HBV：截留、beta 分配的土壤、快慢水库与滞时。</td><td>15 / 17</td><td><span class="tag merged">通过</span></td></tr>
-<tr><td class="mono">flex_topo</td><td>物理模型</td><td>FLEX-Topo：台地、坡地与湿地单元按 Wark 流域的真实面积比共享一个地下水库。</td><td>15 / 17</td><td><span class="tag merged">通过</span></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>物理模型</td><td>美国国家气象局业务用 SAC-SMA + Snow-17 + 伽马单位线，由遗留 Fortran 移植并与之比对。</td><td>15 / 17</td><td><span class="tag merged">通过</span></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>提交模型</td><td>Google Flood Hub 的均值嵌入预报 LSTM，经 OpenHydroNet 以公开权重运行。仅输出流量。</td><td>5 / 18</td><td><span class="tag incomplete">未通过（信息不全）</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>提交模型</td><td>δHBV 2.0，MHPI 的可微 HBV：神经网络写出水桶模型的参数，模型报告蓄水、蒸发，并申报其区域地下水交换。</td><td>11 / 18</td><td><span class="tag violation">未通过（违反）</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>物理模型</td><td>来自 chrimerss/HydrologicModels 的集总 FLEX/HBV：截留、beta 分配的土壤、快慢水库与滞时。</td><td>15 / 18</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>物理模型</td><td>FLEX-Topo：台地、坡地与湿地单元按 Wark 流域的真实面积比共享一个地下水库。</td><td>15 / 18</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>物理模型</td><td>美国国家气象局业务用 SAC-SMA + Snow-17 + 伽马单位线，由遗留 Fortran 移植并与之比对。</td><td>15 / 18</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
 `,
   "probes.h":"检验项一览",
   "probes.intro":"<p>套件中的每一项检验，以及路线图正在等待的每一项。已合并的检验项已在仓库中，并在参照模型上通过验收闸门。征集中的检验项已有名字、尚无人认领，欢迎认领。</p>",
@@ -1078,6 +1083,7 @@ zh: {
 <tr><td class="mono">energy/pet-consistency</td><td>能量</td><td>当模型自身土壤最湿时蒸发达到需求、永不超过需求，最干时蒸发下降。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>能量</td><td>模型作为水量报告的蒸发与其潜热通量所隐含的蒸发：是否是同一个蒸发？</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>能量</td><td>净辐射不变的情况下一个无雨的夏天：干燥地表让出的潜热必须去加热空气。</td><td><span class="tag merged">已合并</span></td></tr>
+<tr><td class="mono">energy/surface-energy-closure</td><td>能量</td><td>每个白天和夜晚的逐小时地表能量预算是否闭合，而没有依赖正负误差抵消？</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">momentum/routing-conservation</td><td>动量</td><td>河道蓄水永不为负，也永不超过其单位线所能容纳的量。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">coupled/snowmelt-energy-water</td><td>耦合</td><td>水量收支中的融雪量必须与融化耗能一致。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/snowpack-mass-closure</td><td>质量</td><td>降雪减融雪减升华减雪水当量变化。</td><td><span class="tag wanted">征集中</span></td></tr>
@@ -1087,7 +1093,6 @@ zh: {
 <tr><td class="mono">mass/extreme-event-closure</td><td>质量</td><td>在超出历史记录的暴雨中保持闭合。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>质量</td><td>在模型拟合范围之外的流域上保持闭合。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/precipitation-counterfactual</td><td>质量</td><td>向同一案例加水，追问水去了哪里。</td><td><span class="tag wanted">征集中</span></td></tr>
-<tr><td class="mono">energy/surface-energy-closure</td><td>能量</td><td>净辐射减感热、潜热与土壤热通量，再减储热变化。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>能量</td><td>完整的积雪能量收支，含冷储量与相变。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">energy/radiation-consistency</td><td>能量</td><td>出射长波辐射必须与所报告的地表温度一致。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">momentum/channel-routing-mass</td><td>动量</td><td>逐河段：入流减出流减河道蓄量变化。</td><td><span class="tag wanted">征集中</span></td></tr>

--- a/src/hydroturing/criteria/coherence.py
+++ b/src/hydroturing/criteria/coherence.py
@@ -53,7 +53,9 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from hydroturing.criteria.base import FAIL, PASS, CriterionResult, criterion, make_window
+from hydroturing.criteria.base import (
+    FAIL, PASS, CriterionResult, criterion, make_window, segments,
+)
 from hydroturing.criteria.response import pick
 from hydroturing.protocol import RunResult
 from hydroturing.spec import ProbeSpec
@@ -294,6 +296,95 @@ def energy_closure(run: RunResult, probe: ProbeSpec, params: dict) -> CriterionR
             "denominator_total": total,
             "mean_step_residual_w_m2": mean_abs,
             "max_step_residual_w_m2": float(np.abs(step_residual).max() / w.dt_days),
+            "floor_w_m2": floor,
+        },
+    )
+
+
+@criterion("energy_closure_by_phase")
+def energy_closure_by_phase(
+    run: RunResult, probe: ProbeSpec, params: dict
+) -> CriterionResult:
+    """The mean absolute skin-budget residual must be small in every block.
+
+    The generator labels contiguous day/night blocks independently of the
+    sign of net radiation. Taking the absolute residual before integration
+    prevents opposite errors from cancelling both within and across blocks.
+    H and LE may have either sign; G is at the actual soil surface, so soil
+    heat storage is not subtracted again from this zero-capacity skin budget.
+    """
+    driver = str(params.get("driver", "rn"))
+    sinks = list(params.get("sinks", ["hfls", "hfss", "hfg"]))
+    threshold = float(params.get("threshold", 0.05))
+    floor = float(params.get("floor", 2.0))
+    segment_column = str(params.get("segment_column", "_regime"))
+
+    w = make_window(run, probe)
+    if driver not in w.forcing.columns:
+        raise ValueError(
+            f"energy_closure_by_phase needs forcing column '{driver}'; "
+            "this probe's generator does not produce it"
+        )
+    for var in sinks:
+        if var not in w.table.columns:
+            raise ValueError(f"energy_closure_by_phase needs '{var}' in the model result")
+    phases = segments(w, segment_column)
+    drive = w.forcing[driver].to_numpy(dtype=float)
+    fluxes = w.table[sinks].to_numpy(dtype=float)
+    finite = np.isfinite(drive) & np.isfinite(fluxes).all(axis=1)
+    if not finite.all():
+        n_bad = int((~finite).sum())
+        return CriterionResult(
+            name="energy_closure_by_phase",
+            status=FAIL,
+            message=f"non-finite surface energy values on {n_bad} scored steps",
+            diagnostics={"non_finite_steps": n_bad},
+        )
+
+    # A Case has one fixed dt, so it cancels from sum(abs(r) * dt) / sum(dt).
+    # Taking the mean directly also avoids rounding an exact tolerance-boundary
+    # value upward through an unnecessary multiplication and division by dt.
+    residual = drive - fluxes.sum(axis=1)
+    blocks = []
+    for label, start, stop in phases:
+        duration_days = (stop - start) * w.dt_days
+        mean_abs = float(np.abs(residual[start:stop]).mean())
+        mean_driver = float(np.abs(drive[start:stop]).mean())
+        allowance = max(threshold * mean_driver, floor)
+        slack = (
+            mean_abs / allowance if allowance > 0
+            else (0.0 if mean_abs == 0 else float("inf"))
+        )
+        blocks.append({
+            "label": label,
+            "start": start,
+            "stop": stop,
+            "duration_hours": duration_days * 24.0,
+            "mean_abs_w_m2": mean_abs,
+            "mean_abs_driver_w_m2": mean_driver,
+            "allowance_w_m2": allowance,
+            "slack": slack,
+            "passed": mean_abs <= allowance,
+        })
+
+    failed = sum(not block["passed"] for block in blocks)
+    worst = max(blocks, key=lambda block: block["slack"])
+    return CriterionResult(
+        name="energy_closure_by_phase",
+        status=PASS if failed == 0 else FAIL,
+        value=worst["slack"],
+        threshold=1.0,
+        message=(
+            f"{failed} of {len(blocks)} phase blocks fail; worst {worst['label']} "
+            f"[{worst['start']}:{worst['stop']}] has mean absolute residual "
+            f"{worst['mean_abs_w_m2']:.3g} W m-2 against "
+            f"{worst['allowance_w_m2']:.3g} W m-2 allowed"
+        ),
+        diagnostics={
+            "blocks": blocks,
+            "failed_blocks": failed,
+            "worst_block": worst,
+            "relative_threshold": threshold,
             "floor_w_m2": floor,
         },
     )

--- a/src/hydroturing/criteria/coherence.py
+++ b/src/hydroturing/criteria/coherence.py
@@ -238,9 +238,10 @@ def energy_closure(run: RunResult, probe: ProbeSpec, params: dict) -> CriterionR
 
     Separate from `closure` rather than a denominator of it, because `closure`
     differences the probe's water states and this budget has none: `hfg` is
-    the storage term, and a model that reports it has already said where the
-    energy went. Keeping them apart also lets one probe score both budgets
-    without two criteria of the same name.
+    the downward flux at the actual soil surface, already corrected by the
+    adapter for storage above a deeper flux boundary if needed. Subsurface
+    storage is not subtracted again. Keeping the budgets apart also lets one
+    probe score both without two criteria of the same name.
 
     Net radiation changes sign every night, so the relative test carries an
     absolute floor as the module docstring of `closure` prescribes.
@@ -378,7 +379,9 @@ def energy_closure_by_phase(
             f"{failed} of {len(blocks)} phase blocks fail; worst {worst['label']} "
             f"[{worst['start']}:{worst['stop']}] has mean absolute residual "
             f"{worst['mean_abs_w_m2']:.3g} W m-2 against "
-            f"{worst['allowance_w_m2']:.3g} W m-2 allowed"
+            f"{worst['allowance_w_m2']:.3g} W m-2 allowed; "
+            "assumes ground heat is mapped to the actual soil surface "
+            "(an uncorrected deeper-boundary flux can also cause a residual)"
         ),
         diagnostics={
             "blocks": blocks,

--- a/src/hydroturing/spec.py
+++ b/src/hydroturing/spec.py
@@ -72,6 +72,7 @@ FULL_WINDOW = "full"
 TRUSTED_SUBPROCESS_MODELS = {
     "reference_bucket",
     "reference_coupled",
+    "reference_diurnal_bias",
     "reference_two_head",
     "reference_constant_lambda",
     "reference_sublimation_blind",

--- a/src/hydroturing/spec.py
+++ b/src/hydroturing/spec.py
@@ -21,8 +21,9 @@ SCHEMA_DIR = REPO_ROOT / "schemas"
 # Canonical variable names. Water fluxes are mm per timestep-day; states are
 # mm. `dis` is m3 s-1, because that is what models report. The surface energy
 # fluxes are W m-2, positive away from the surface for the turbulent terms and
-# positive into the ground for `hfg`, which is the surface energy budget's
-# storage term: a model that reports it does not also need an energy state.
+# positive into the ground at the actual soil surface for `hfg`. Adapters
+# must correct a deeper-boundary flux for heat storage above that depth;
+# subsurface storage is not also subtracted from the surface budget.
 # `sbl` is a component of `evspsbl`, never an addition to it.
 FLUX_VARS = ("pr", "evspsbl", "mrro", "dis", "gwex", "sbl", "hfls", "hfss", "hfg")
 STATE_VARS = ("mrso", "snw", "canopy", "gw", "channel")

--- a/tests/test_surface_energy_closure.py
+++ b/tests/test_surface_energy_closure.py
@@ -1,0 +1,115 @@
+"""Counterexamples for temporal surface energy closure, independent of the gate."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hydroturing.criteria import get
+from hydroturing.criteria.base import FAIL, PASS
+from hydroturing.protocol import Case, RunResult
+from hydroturing.spec import TIMESTEP_DAYS
+
+
+def build(residual, rn=100.0, phases=None, spinup=0, timestep="PT1H"):
+    """Give H a known accounting error; no model physics is needed to hide it."""
+    residual = np.asarray(residual, dtype=float)
+    n = len(residual)
+    rn = np.broadcast_to(rn, (n,))
+    if phases is None:
+        phases = np.where(np.arange(n) % 24 < 12, "day", "night")
+    times = pd.date_range(
+        "2001-07-01T06:00", periods=n,
+        freq=pd.Timedelta(days=TIMESTEP_DAYS[timestep]),
+    )
+    forcing = pd.DataFrame({"time": times, "rn": rn, "_regime": phases})
+    table = pd.DataFrame({
+        "time": times, "hfls": 30.0, "hfss": rn - 40.0 - residual, "hfg": 10.0,
+    })
+    case = Case(
+        probe_id="t", seed=1, forcing=forcing, static={},
+        spinup_steps=spinup, timestep=timestep,
+    )
+    return RunResult(case=case, table=table, meta={}, wall_seconds=0.0)
+
+
+def score(run, **params):
+    return get("energy_closure_by_phase")(run, None, params)
+
+
+@pytest.mark.parametrize("residual", [
+    np.repeat([20.0, -20.0], 12),
+    np.tile([20.0, -20.0], 12),
+], ids=["day-night-cancellation", "within-phase-cancellation"])
+def test_opposite_errors_that_pass_cumulative_closure_fail(residual):
+    run = build(residual, rn=np.repeat([100.0, -20.0], 12))
+    assert get("energy_closure")(run, None, {}).status == PASS
+    result = score(run)
+    assert result.status == FAIL
+    assert result.diagnostics["failed_blocks"] == 2
+    assert result.diagnostics["worst_block"]["mean_abs_w_m2"] == pytest.approx(20.0)
+
+
+@pytest.mark.parametrize("rn,error,expected", [
+    (100.0, 4.0, PASS),
+    (100.0, 5.0, PASS),
+    (100.0, 6.0, FAIL),
+    (2.0, 1.0, PASS),
+    (2.0, 2.0, PASS),
+    (2.0, 3.0, FAIL),
+    (0.0, 1.0, PASS),
+], ids=[
+    "relative-pass", "relative-boundary", "relative-fail",
+    "floor-pass", "floor-boundary", "floor-fail", "zero-radiation",
+])
+def test_relative_allowance_and_absolute_floor(rn, error, expected):
+    result = score(build(np.full(24, error), rn=rn))
+    assert result.status == expected, result.message
+
+
+def test_exact_closure_allows_negative_turbulent_fluxes():
+    run = build(np.zeros(24), rn=np.repeat([100.0, -20.0], 12))
+    run.table["hfls"] = np.repeat([-10.0, 10.0], 12)
+    run.table["hfss"] = run.case.forcing["rn"] - run.table["hfls"] - run.table["hfg"]
+    assert (run.table["hfls"] < 0).any() and (run.table["hfss"] < 0).any()
+    assert score(run).status == PASS
+
+
+def test_spinup_is_not_scored_and_block_indices_start_at_the_scored_window():
+    run = build(np.r_[np.full(24, 500.0), np.zeros(24)], spinup=24)
+    result = score(run)
+    assert result.status == PASS
+    blocks = result.diagnostics["blocks"]
+    assert [(b["start"], b["stop"]) for b in blocks] == [(0, 12), (12, 24)]
+
+
+def test_a_bad_day_is_not_diluted_by_other_days_with_the_same_label():
+    # The first day has 8 W m-2 of error; the next has none. Grouping all
+    # 'day' rows would produce 4 W m-2 and incorrectly pass the 5 W m-2 bound.
+    run = build(np.r_[np.full(12, 8.0), np.zeros(36)])
+    result = score(run)
+    assert result.status == FAIL
+    assert result.diagnostics["failed_blocks"] == 1
+    assert len(result.diagnostics["blocks"]) == 4
+    assert result.diagnostics["worst_block"]["start"] == 0
+
+
+def test_duration_uses_the_case_timestep_and_configured_segment_column():
+    run = build(np.full(8, 3.0), phases=["day"] * 8, timestep="PT15M")
+    run.case.forcing = run.case.forcing.rename(columns={"_regime": "_phase"})
+    result = score(run, segment_column="_phase", threshold=0.01, floor=4.0)
+    assert result.status == PASS
+    block = result.diagnostics["blocks"][0]
+    assert block["duration_hours"] == pytest.approx(2.0)
+    assert block["mean_abs_w_m2"] == pytest.approx(3.0)
+    assert block["allowance_w_m2"] == pytest.approx(4.0)
+
+
+@pytest.mark.parametrize("invalid", [np.nan, np.inf, -np.inf])
+def test_non_finite_model_flux_is_a_failure(invalid):
+    run = build(np.zeros(24))
+    run.table.loc[12, "hfss"] = invalid
+    result = score(run)
+    assert result.status == FAIL
+    assert result.diagnostics["non_finite_steps"] == 1

--- a/tests/test_surface_energy_closure.py
+++ b/tests/test_surface_energy_closure.py
@@ -76,6 +76,32 @@ def test_exact_closure_allows_negative_turbulent_fluxes():
     assert score(run).status == PASS
 
 
+@pytest.mark.parametrize("amplitude_k", [0.5, 2.0])
+def test_plate_depth_flux_needs_storage_correction(amplitude_k):
+    # Known heat content of a uniform 5 cm layer above a plate. Temperature
+    # is its layer mean at interval endpoints, with a peak at 14:00.
+    run = build(np.zeros(48), rn=np.tile(np.repeat([100.0, -30.0], 12), 2))
+    endpoint_hours = 6.0 + np.arange(49)
+    temperature = 20.0 + amplitude_k * np.cos(
+        2.0 * np.pi * (endpoint_hours - 14.0) / 24.0
+    )
+    heat_content = 2.0e6 * 0.05 * temperature  # J m-2
+    storage_rate = np.diff(heat_content) / 3600.0  # W m-2
+    surface_flux = run.table["hfg"].copy()
+    run.table["hfg"] = surface_flux - storage_rate
+
+    # Daily storage changes cancel, hiding the wrong boundary cumulatively.
+    assert get("energy_closure")(run, None, {}).status == PASS
+    uncorrected = score(run)
+    assert uncorrected.status == FAIL
+    assert "uncorrected deeper-boundary flux" in uncorrected.message
+
+    # The adapter supplies the independently known layer storage, not a
+    # correction diagnosed from the surface-budget residual.
+    run.table["hfg"] += storage_rate
+    assert score(run).status == PASS
+
+
 def test_spinup_is_not_scored_and_block_indices_start_at_the_scored_window():
     run = build(np.r_[np.full(24, 500.0), np.zeros(24)], spinup=24)
     result = score(run)

--- a/tests/test_surface_energy_probe.py
+++ b/tests/test_surface_energy_probe.py
@@ -1,0 +1,92 @@
+"""The hourly probe must reach models intact, with complete scored phases.
+
+Criterion arithmetic is tested separately. These tests cover mistakes in
+generation and staging that would otherwise change the experiment itself.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hydroturing import registry
+from hydroturing.harness import (
+    build_case,
+    load_generator,
+    resolve_window_days,
+    select_window,
+    window_case,
+)
+from hydroturing.protocol import FORCING_FILE, stage
+
+
+@pytest.fixture(scope="module")
+def probe():
+    return registry.find_probe("energy/surface-energy-closure")
+
+
+def test_generator_reproduces_bytes_and_changes_the_weather_with_seed(probe):
+    generate = load_generator(probe).generate
+    first, static = generate(0)
+    repeated, repeated_static = generate(0)
+    other, _ = generate(1)
+    assert first.to_csv(index=False) == repeated.to_csv(index=False)
+    assert static == repeated_static
+    assert not first["rn"].equals(other["rn"])
+
+
+@pytest.mark.parametrize("seed", [0, 19])
+def test_case_has_warm_bare_conditions_and_complete_hourly_phases(probe, seed):
+    case = build_case(probe, seed)
+    assert case.n_steps == 384
+    assert case.spinup_steps == 48
+    assert case.timestep == "PT1H"
+    time = pd.to_datetime(case.forcing["time"])
+    assert time.diff().iloc[1:].eq(pd.Timedelta(hours=1)).all()
+    assert time.iloc[0].hour == 6
+    assert case.forcing["tas"].gt(0.0).all()
+    assert case.static["canopy_capacity_mm"] == 0.0
+
+    scored = case.after_spinup(case.forcing)
+    assert len(scored) == 336
+    labels = scored["_regime"]
+    groups = labels.ne(labels.shift()).cumsum()
+    sizes = labels.groupby(groups).size()
+    assert len(sizes) == 28
+    assert sizes.eq(12).all()
+    assert labels.groupby(groups).first().tolist() == ["day", "night"] * 14
+    hours = pd.to_datetime(scored["time"]).dt.hour
+    assert np.array_equal(labels.eq("day"), (hours >= 6) & (hours < 18))
+    # Weak radiation exercises the absolute allowance in the actual forcing.
+    assert scored["rn"].abs().lt(40.0).any()
+
+
+def test_staging_strips_phase_annotation_but_preserves_hourly_forcing(probe, tmp_path):
+    case = build_case(probe, 0)
+    model = registry.find_model("reference_coupled")
+    request_path = stage(tmp_path, case, probe, model)
+    request = json.loads(request_path.read_text())
+    staged = pd.read_csv(tmp_path / FORCING_FILE)
+    assert "_regime" not in staged.columns
+    assert "_regime" in case.forcing.columns
+    assert request["timestep"] == "PT1H"
+    assert request["n_steps"] == 384
+    pd.testing.assert_frame_equal(staged, case.forcing.drop(columns="_regime"))
+
+
+def test_default_and_short_requested_windows_keep_all_scored_phases(probe):
+    # A submitted model normally gets seven hourly days. Here the minimum
+    # must retain fourteen, including when a caller explicitly asks for less.
+    model = replace(registry.find_model("reference_coupled"), name="submitted_energy")
+    assert resolve_window_days(model, probe) == 14
+    assert resolve_window_days(model, probe, override=1) == 14
+    case = build_case(probe, 0)
+    bounds = select_window(case, probe, resolve_window_days(model, probe))
+    cut = window_case(case, bounds)
+    assert cut.spinup_steps == 48
+    assert cut.window["rows"] == 336
+    pd.testing.assert_frame_equal(cut.forcing, case.forcing)


### PR DESCRIPTION
Closes #15

## What this probe asserts

A model with +20 W m-2 of surface-energy residual by day and -20 W m-2 by night passes the existing signed cumulative `energy_closure`. This probe catches that temporal cancellation by requiring every contiguous day/night block to satisfy

```text
mean(abs(Rn - H - LE - G)) <= max(0.05 * mean(abs(Rn)), 2 W m-2).
```

The seeded hourly case contains two spinup days and fourteen scored days, starting at 06:00 local-solar time so all 28 scored blocks are complete. The new `energy_closure_by_phase` reuses the existing window/segment machinery; the cumulative criterion is unchanged. `reference_coupled` now declares its verified PT1H support, and `reference_diurnal_bias` changes only H using the current timestamp.

The boundary is a snow-free, zero-capacity bare skin with G at the actual soil surface. A buried heat-flux plate must first be corrected for heat storage between the plate and the surface; the criterion does not subtract that storage again. Negative turbulent fluxes are permitted. Boundary compatibility needs adapter documentation/review; passing does not establish realistic partitioning, thermal inertia, or component accuracy.

## Discrimination

| Reference model | Expected | Criterion that catches it |
| --- | --- | --- |
| `reference_coupled` | PASS | n/a |
| `reference_diurnal_bias` | FAIL | `energy_closure_by_phase` |

Both outcomes hold for the five declared gate seeds. An additional 20-seed check through the real adapter subprocess path found: positive control 20/20 passes, temporal-bias control 20/20 fails all 28 blocks, and the unchanged cumulative criterion still passes the bias control 20/20. Unit regressions also cover cancellation within a phase and weak-radiation allowances.

## Validation

- After rebasing onto main at `8d2e92e`, `ht validate`: 18 probes, 30 models.
- `pytest -q`: 310 passed, 1 xfailed. The expected xfail is the existing pending affiliation for `mass/time-origin-invariance`; the surface-energy author checks pass.
- `ht gate --probe energy/surface-energy-closure`: passed for all five declared seeds on the rebased branch.
- At initial submission, `ht gate` passed for all 17 probes then present; the full-suite gate has not been rerun after this rebase.
- At initial submission, `ht verify-adapter --model <reference> --probe energy/surface-energy-closure`: both references pass with 384 rows.
- At initial submission, the new-probe gate on Windows restricted to two logical CPUs (processor affinity mask 3): 1.59 s including ten adapter runs; the per-run budget is 60 s. This is a local two-CPU measurement, not a claim about an already-completed GitHub runner.
- `ht run --model <model> --probe energy/surface-energy-closure --gate-seeds --csv models/result.csv` archived all five existing evaluated models as INCOMPLETE for missing hfls/hfss/hfg; Google and dhbv2 additionally declare no PT1H support. No physical-violation claim is made for them.

README, roadmap, contributor credit, the three-language site/flowchart and the probe-writing reference are synchronized. The combined suite includes both `mass/time-origin-invariance` and `energy/surface-energy-closure`; both result blocks are preserved. Physical-reference summaries retain main's PASS wording, now 15/18 with three energy-flux probes INCOMPLETE. Archived INCOMPLETE outcomes and the harness verdict logic are unchanged.

The focused tests verify deterministic forcing, complete blocks, annotation stripping, the minimum window, tolerance boundaries, spinup exclusion, and the buried-plate storage correction. Han Wang's full affiliation and ORCID are in `probe.yaml`, the contributor row is updated, and `CITATION.cff` adds the author after Siavash Shams.

## Checklist

- [x] There is an `accepted` proposal issue and this PR closes it
- [x] Author name, affiliation and ORCID are supplied in `probe.yaml`; `CONTRIBUTORS.md` and `CITATION.cff` are synchronized
- [x] `ht validate` passes
- [x] `ht gate --probe energy/surface-energy-closure` passes
- [x] The generator is deterministic given a seed and commits no data
- [x] The probe runs in under a minute on two CPUs (local affinity-constrained measurement above)
- [x] Tolerance and denominator are justified in `probe.yaml`
- [x] I constructed a model that passes cumulative closure with unphysical temporal errors, and the new criterion catches it