### PR TITLE
Ask for author details at proposal time and check them at merge

### DIFF
--- a/.github/ISSUE_TEMPLATE/model_submission.yml
+++ b/.github/ISSUE_TEMPLATE/model_submission.yml
@@ -22,6 +22,23 @@ body:
         maintainer can make alone. See
         [CONTRIBUTING.md](https://github.com/Flood-Lab/HydroTuring/blob/main/CONTRIBUTING.md#credit).
 
+        Because accepted proposals accumulate towards authorship, the form
+        asks who is proposing. This is what CONTRIBUTORS.md and the paper's
+        author list are built from. A contact email is not asked for on a
+        public issue; the maintainer will ask for one privately if and when
+        your proposals cross the authorship line.
+
+  - type: input
+    id: proposer
+    attributes:
+      label: Proposer
+      description: >
+        Your full name as it should be printed, your affiliation with
+        department and city (or "independent"), and your ORCID if you have
+        one.
+      placeholder: "Jane Doe, Department of Civil Engineering, University of Somewhere, Boulder CO, 0000-0002-1825-0097"
+    validations: {required: true}
+
   - type: input
     id: model_name
     attributes:

--- a/.github/ISSUE_TEMPLATE/probe_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/probe_proposal.yml
@@ -15,6 +15,27 @@ body:
         earns co-authorship on the benchmark paper. See
         [CONTRIBUTING.md](https://github.com/Flood-Lab/HydroTuring/blob/main/CONTRIBUTING.md#credit).
 
+        Because a merged probe is authorship, the form asks who you are up
+        front. What you write here goes into `authors` in your `probe.yaml`,
+        into CONTRIBUTORS.md and CITATION.cff, and onto the paper's author
+        list, so it does not have to be gathered again at submission time.
+        A contact email is not asked for on a public issue; the maintainer
+        will ask for one privately when the probe merges.
+
+  - type: textarea
+    id: authors
+    attributes:
+      label: Authors
+      description: >
+        One line per author, in the order they should appear: full name as it
+        should be printed, affiliation with department and city (or
+        "independent"), and ORCID if you have one. Every author listed here
+        is a co-author of the paper once the probe merges.
+      placeholder: |
+        Jane Doe, Department of Civil Engineering, University of Somewhere, Boulder CO, 0000-0002-1825-0097
+        Ada Lovelace, independent, 0000-0001-5109-3700
+    validations: {required: true}
+
   - type: dropdown
     id: law
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE/new_probe.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_probe.md
@@ -20,6 +20,7 @@ Every probe must separate the reference models. Fill in what `ht gate` reports:
 ## Checklist
 
 - [ ] There is an `accepted` proposal issue and this PR closes it
+- [ ] `authors` in `probe.yaml` names every author with `name`, `affiliation` and, where you have one, `orcid`, matching the proposal issue; CONTRIBUTORS.md, CITATION.cff and the paper's author list are built from it
 - [ ] `ht validate` passes
 - [ ] `ht gate --probe <id>` passes
 - [ ] The generator is deterministic given a seed and commits no data

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,9 +216,18 @@ For a merged probe:
    variable the physical models do not report, their standing changes from
    "PASS, N of N" to "N of N+1, INCOMPLETE on ..." and the sentence above the
    table that says what they must pass changes with it.
-2. `CONTRIBUTORS.md`: a row in the probes table naming the author. A merged
-   probe earns co-authorship, so this row is the record of that.
-3. `ROADMAP.md`: the entry moves from unclaimed to `**merged**`, under the
+2. `CONTRIBUTORS.md`: a row in the probes table naming the author with
+   their affiliation, as `Name (Institution)`. A merged probe earns
+   co-authorship, so this row is the record of that. The affiliation comes
+   from `authors` in the probe's `probe.yaml`; if it is missing there, ask
+   the author before merging rather than after, because the test that
+   checks it (`test_probe_authors_carry_an_affiliation`) fails the build.
+3. `CITATION.cff`: an `authors` entry for every probe author not already
+   listed, with `given-names`, `family-names`, `affiliation` and `orcid` as
+   a full `https://orcid.org/` URL. This is the software's author list and
+   the paper's starting point. Contact emails stay out of the repository;
+   ask for one privately at merge time.
+4. `ROADMAP.md`: the entry moves from unclaimed to `**merged**`, under the
    id the probe actually took, with the author named. Rewrite the paragraph
    above it if it counted the unclaimed entries.
 4. `site/index.html`, three times, once per language block: the row in

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,16 @@ authors:
     family-names: Li
     affiliation: University of Colorado Boulder
     email: chrimerss@gmail.com
+  # Probe authors, in order of first merged probe. One merged probe is
+  # co-authorship (CONTRIBUTING.md#credit); tests/test_docs_in_sync.py checks
+  # that every probe author appears here.
+  - given-names: Changming
+    family-names: Li
+    affiliation: South China University of Technology
+    orcid: "https://orcid.org/0000-0003-1793-1824"
+  - given-names: Siavash
+    family-names: Shams
+    # affiliation and orcid requested from the author, 2026-09-11
 repository-code: "https://github.com/Flood-Lab/HydroTuring"
 url: "https://flood-lab.github.io/HydroTuring/"
 license: MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,24 @@ it that way.
 are named in every report that runs the probe and in each Zenodo release.
 Nobody's contribution disappears into a commit log.
 
+**What we need from you.** Authorship on a paper needs more than a GitHub
+handle, and gathering it after the fact is how names end up wrong. So the
+proposal forms ask for it up front, and a probe pull request is expected to
+carry it in `authors` in `probe.yaml`:
+
+| Field | Required | Where it ends up |
+| --- | --- | --- |
+| `name`, as it should be printed | yes | `probe.yaml`, every report, CONTRIBUTORS.md, CITATION.cff, the paper |
+| `affiliation`, with department and city, or "independent" | yes | CONTRIBUTORS.md, CITATION.cff, the paper |
+| `orcid` | if you have one | CITATION.cff, the paper |
+| `github` | optional | the repository only |
+
+A contact email is not asked for in a public file or issue. The maintainer
+asks for one privately when a probe merges or when model proposals cross the
+line, and it is kept out of the repository. `tests/test_docs_in_sync.py`
+checks that every merged probe's authors carry an affiliation, so a pull
+request without one fails the build rather than the paper.
+
 **On the benchmark paper.** The threshold for co-authorship is:
 
 | Contribution | Counts as |

--- a/docs/writing-a-probe.md
+++ b/docs/writing-a-probe.md
@@ -52,6 +52,12 @@ probes/<law>/<slug>/
   README.md      the physics in prose
 ```
 
+`authors` in `probe.yaml` is the record the paper's author list is built
+from, so fill it in as it should be printed: `name` and `affiliation`
+(department and city, or "independent") for every author, and `orcid` where
+you have one. The build checks that every merged probe's authors carry an
+affiliation. See [CONTRIBUTING.md](../CONTRIBUTING.md#credit).
+
 `probes/mass/catchment-closure/` is the reference implementation. Read it
 before you start.
 

--- a/tests/test_docs_in_sync.py
+++ b/tests/test_docs_in_sync.py
@@ -13,10 +13,19 @@ import csv
 import re
 
 import pytest
+import yaml
 
 from hydroturing.spec import FLUX_VARS, REPO_ROOT, STATE_VARS, load_model, load_probe
 
-PROBE_IDS = sorted(load_probe(p).id for p in REPO_ROOT.glob("probes/*/*/probe.yaml"))
+PROBES = {p.id: p for p in (load_probe(x) for x in REPO_ROOT.glob("probes/*/*/probe.yaml"))}
+PROBE_IDS = sorted(PROBES)
+
+# Probes merged before the proposal form asked for an affiliation. Each entry
+# is a request outstanding with the author; remove it when the answer lands
+# in probe.yaml. Nothing merged after this list was written may be added to it.
+AFFILIATION_PENDING = {
+    "mass/time-origin-invariance",  # asked 2026-09-11
+}
 EVALUATED_MODELS = sorted(
     load_model(p).name
     for p in REPO_ROOT.glob("models/*/model.yaml")
@@ -40,6 +49,38 @@ def test_contributors_credit_the_probe(probe_id):
     assert f"| `{probe_id}` |" in read("CONTRIBUTORS.md"), (
         f"{probe_id} has no row in CONTRIBUTORS.md; a merged probe earns co-authorship"
     )
+
+
+@pytest.mark.parametrize("probe_id", PROBE_IDS)
+def test_probe_authors_carry_an_affiliation(probe_id):
+    """A merged probe is co-authorship, and a paper needs more than a handle."""
+    if probe_id in AFFILIATION_PENDING:
+        pytest.xfail(f"{probe_id}: affiliation requested from the author, not yet supplied")
+    for author in PROBES[probe_id].authors:
+        assert author.get("affiliation", "").strip(), (
+            f"{probe_id}: author {author.get('name')!r} has no affiliation in probe.yaml; "
+            "CONTRIBUTORS.md, CITATION.cff and the paper's author list are built from it"
+        )
+
+
+def _cff_authors() -> set[tuple[str, str]]:
+    cff = yaml.safe_load(read("CITATION.cff"))
+    return {
+        (a.get("given-names", "").strip(), a.get("family-names", "").strip())
+        for a in cff.get("authors", [])
+    }
+
+
+@pytest.mark.parametrize("probe_id", PROBE_IDS)
+def test_citation_lists_every_probe_author(probe_id):
+    """CITATION.cff is the software's author list; a probe author belongs on it."""
+    listed = _cff_authors()
+    for author in PROBES[probe_id].authors:
+        given, _, family = author["name"].strip().rpartition(" ")
+        assert (given, family) in listed, (
+            f"{probe_id}: author {author['name']!r} is not in CITATION.cff "
+            f"(expected given-names {given!r}, family-names {family!r})"
+        )
 
 
 @pytest.mark.parametrize("probe_id", PROBE_IDS)


### PR DESCRIPTION
Closes the gap surfaced by #11, where the first external probe merged with a name and a GitHub handle and nothing else.

- Probe and model proposal forms ask for the printed name, affiliation and ORCID up front; contact email is requested privately at merge time and stays out of the repository.
- The probe PR template, CONTRIBUTING's credit section, the probe-writing guide and the AGENTS.md merge checklist say where each field ends up.
- `tests/test_docs_in_sync.py` checks that every probe author carries an affiliation in `probe.yaml` and appears in `CITATION.cff`. `mass/time-origin-invariance` is listed as pending until its author replies; any new probe without an affiliation fails the build.
- `CITATION.cff` lists the two contributed-probe authors after the maintainer.

Full suite: 281 passed, 1 xfailed (the pending affiliation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)