### PR TITLE
Record Siavash Shams's affiliation for mass/time-origin-invariance

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ authors:
     orcid: "https://orcid.org/0000-0003-1793-1824"
   - given-names: Siavash
     family-names: Shams
-    # affiliation and orcid requested from the author, 2026-09-11
+    affiliation: Department of Electrical Engineering, Columbia University, New York, NY, USA
   - given-names: Han
     family-names: Wang
     affiliation: >-

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,7 +27,7 @@ long.
 | `mass/response-nonnegativity` | Zhi Li (CU Boulder) |
 | `mass/antecedent-monotonicity` | Zhi Li (CU Boulder) |
 | `mass/phase-counterfactual` | Zhi Li (CU Boulder) |
-| `mass/time-origin-invariance` | Siavash Shams |
+| `mass/time-origin-invariance` | Siavash Shams (Columbia University) |
 | `energy/pet-consistency` | Zhi Li (CU Boulder) |
 | `energy/latent-heat-et-consistency` | Changming Li (SCUT) |
 | `energy/evaporative-partition` | Changming Li (SCUT) |

--- a/probes/mass/time-origin-invariance/probe.yaml
+++ b/probes/mass/time-origin-invariance/probe.yaml
@@ -6,6 +6,7 @@ version: 1
 
 authors:
   - name: Siavash Shams
+    affiliation: Department of Electrical Engineering, Columbia University, New York, NY, USA
     github: SiavashShams
 
 description: >

--- a/tests/test_docs_in_sync.py
+++ b/tests/test_docs_in_sync.py
@@ -23,9 +23,7 @@ PROBE_IDS = sorted(PROBES)
 # Probes merged before the proposal form asked for an affiliation. Each entry
 # is a request outstanding with the author; remove it when the answer lands
 # in probe.yaml. Nothing merged after this list was written may be added to it.
-AFFILIATION_PENDING = {
-    "mass/time-origin-invariance",  # asked 2026-09-11
-}
+AFFILIATION_PENDING: set[str] = set()
 EVALUATED_MODELS = sorted(
     load_model(p).name
     for p in REPO_ROOT.glob("models/*/model.yaml")


### PR DESCRIPTION
The author's reply to the request made when #11 merged. Affiliation (Department of Electrical Engineering, Columbia University, New York, NY, USA) goes into the probe manifest, `CITATION.cff` and the CONTRIBUTORS row; the pending list in `tests/test_docs_in_sync.py` is now empty, so the affiliation check runs for every probe with no exemptions. No ORCID was supplied; the contact email stays out of the repository.

`ht validate` and the docs-sync tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)