### PR TITLE
[PROBE: mass] Partition added and removed rain among evaporation, runoff and storage

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,6 +23,12 @@ authors:
       Department of Civil and Environmental Engineering,
       The Hong Kong University of Science and Technology, Hong Kong, China
     orcid: "https://orcid.org/0000-0001-9771-1324"
+  - given-names: Qingyi
+    family-names: Yang
+    affiliation: >-
+      Department of Civil and Environmental Engineering (D.I.C.A.),
+      Politecnico di Milano, Milano 20133, Italy
+    orcid: "https://orcid.org/0009-0001-9836-4261"
 repository-code: "https://github.com/Flood-Lab/HydroTuring"
 url: "https://flood-lab.github.io/HydroTuring/"
 license: MIT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,7 @@ long.
 | `mass/antecedent-monotonicity` | Zhi Li (CU Boulder) |
 | `mass/phase-counterfactual` | Zhi Li (CU Boulder) |
 | `mass/time-origin-invariance` | Siavash Shams (Columbia University) |
+| `mass/precipitation-counterfactual` | Qingyi Yang (Politecnico di Milano) |
 | `energy/pet-consistency` | Zhi Li (CU Boulder) |
 | `energy/latent-heat-et-consistency` | Changming Li (SCUT) |
 | `energy/evaporative-partition` | Changming Li (SCUT) |

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ not.
 
 ## The probes
 
-Eighteen: thirteen under mass, four under energy and one under momentum. Each was
+Nineteen: fourteen under mass, four under energy and one under momentum. Each was
 merged only after the acceptance gate saw it pass four physical models, a
 bucket that conserves water exactly, two hand-written FLEX models and the
 NWS's SAC-SMA with Snow-17, and fail a purpose-built broken one on the
 named criterion. A probe that fails a
 physical model is examined before the model is; that is the first thing done
-with any probe pull request. Eleven of the eighteen can be scored on a model
+with any probe pull request. Eleven of the nineteen can be scored on a model
 that reports runoff and nothing else. `ht list` prints them;
-[ROADMAP.md](ROADMAP.md#probes-we-want) has the fourteen more we want, all
+[ROADMAP.md](ROADMAP.md#probes-we-want) has the thirteen more we want, all
 unclaimed.
 
 | Probe | Law | What it asks | The broken model it catches |
@@ -94,6 +94,7 @@ unclaimed.
 | [`mass/antecedent-monotonicity`](probes/mass/antecedent-monotonicity) | mass | The same storm after a dry month and a wet one: the wetter catchment runs off more, and no more than the extra water. | `reference_cheater` |
 | [`mass/phase-counterfactual`](probes/mass/phase-counterfactual) | mass | The same water falling as rain instead of snow: timing moves, the integrated volumes may not. | `reference_sublimating` |
 | [`mass/time-origin-invariance`](probes/mass/time-origin-invariance) | mass | The same weather under a 28-year calendar shift that preserves seasons and leap days: evaporation, runoff and water stores must agree. | `reference_calendar`, `reference_degenerate`, `reference_leaky` |
+| [`mass/precipitation-counterfactual`](probes/mass/precipitation-counterfactual) | mass | The same seed 20% wetter, 10% wetter and 20% drier: the water added or removed must be partitioned among evaporation, runoff and storage, and runoff must rise from drier to wetter. | `reference_cheater`, `reference_leaky`, `reference_degenerate` |
 | [`energy/pet-consistency`](probes/energy/pet-consistency) | energy | Evaporation reaches demand when the model's own soil is wettest, stays below it, and falls when the soil is driest. | `reference_thirsty` |
 | [`energy/latent-heat-et-consistency`](probes/energy/latent-heat-et-consistency) | energy | The evaporation a model reports as water and the evaporation implied by the latent heat it reports: are they the same evaporation? | `reference_two_head`, `reference_constant_lambda`, `reference_sublimation_blind`, `reference_energy_leak` |
 | [`energy/evaporative-partition`](probes/energy/evaporative-partition) | energy | One summer without rain under net radiation that did not change: the latent heat a drying surface gives up has to warm the air. | `reference_two_head`, `reference_ground_dodge` |
@@ -121,12 +122,12 @@ goes untested.
 
 | Model | Kind | What it does | Standing |
 | --- | --- | --- | --- |
-| [`google_flood_forecast`](models/google_flood_forecast) | submitted | The mean-embedding forecast LSTM behind Google Flood Hub, at the published weights. Predicts discharge and nothing else. | **FAIL (INCOMPLETE)**, 5 of 18 probes passed. Runoff-only, so seven probes cannot ask it anything; of the eleven that ask on runoff alone it passes the runoff bounds, memory, area, causality and steady state, and fails step, extreme rain, phase, warming, dry-down, and a 0.18 mm/day dip after an added storm |
-| [`dhbv2`](models/dhbv2) | submitted | δHBV 2.0, the MHPI group's differentiable HBV: neural networks write the parameters of a bucket model that reports its stores and its evaporation. | **FAIL (VIOLATION)**, 11 of 18 probes passed. Its learned regional-groundwater term, declared as `gwex`, closes the budget to 1e-8; what remains is a learned field capacity twice the catchment's, a response to doubled rain above the rain added, a runoff depth that changes with the area it is told, and a third more runoff when snow falls as rain |
+| [`google_flood_forecast`](models/google_flood_forecast) | submitted | The mean-embedding forecast LSTM behind Google Flood Hub, at the published weights. Predicts discharge and nothing else. | **FAIL (INCOMPLETE)**, 5 of 19 probes passed. Runoff-only, so eight probes cannot ask it anything; of the eleven that ask on runoff alone it passes the runoff bounds, memory, area, causality and steady state, and fails step, extreme rain, phase, warming, dry-down, and a 0.18 mm/day dip after an added storm |
+| [`dhbv2`](models/dhbv2) | submitted | δHBV 2.0, the MHPI group's differentiable HBV: neural networks write the parameters of a bucket model that reports its stores and its evaporation. | **FAIL (VIOLATION)**, 11 of 19 probes passed. Its learned regional-groundwater term, declared as `gwex`, closes the budget to 1e-8; what remains is a learned field capacity twice the catchment's, a response to doubled rain above the rain added, a runoff depth that changes with the area it is told, and a third more runoff when snow falls as rain |
 | `reference_bucket` | exact | conserves water exactly by construction | must pass every probe that can ask it anything; INCOMPLETE on the three energy-flux probes, which need fluxes it does not report |
-| [`flex_lumped`](models/flex_lumped) | physical | lumped FLEX/HBV: interception, beta-partitioned unsaturated store, fast and slow reservoirs, triangular lag | must pass every probe that can ask it anything; **PASS**, 15 of 18, INCOMPLETE on the three energy-flux probes |
-| [`flex_topo`](models/flex_topo) | physical | FLEX-Topo: plateau, hillslope and wetland units on real Wark fractions sharing one groundwater store | must pass every probe that can ask it anything; **PASS**, 15 of 18, INCOMPLETE on the three energy-flux probes |
-| [`sacsma_snow17`](models/sacsma_snow17) | physical | the NWS's SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it | must pass every probe that can ask it anything; **PASS**, 15 of 18, INCOMPLETE on the three energy-flux probes |
+| [`flex_lumped`](models/flex_lumped) | physical | lumped FLEX/HBV: interception, beta-partitioned unsaturated store, fast and slow reservoirs, triangular lag | must pass every probe that can ask it anything; **PASS**, 16 of 19, INCOMPLETE on the three energy-flux probes |
+| [`flex_topo`](models/flex_topo) | physical | FLEX-Topo: plateau, hillslope and wetland units on real Wark fractions sharing one groundwater store | must pass every probe that can ask it anything; **PASS**, 16 of 19, INCOMPLETE on the three energy-flux probes |
+| [`sacsma_snow17`](models/sacsma_snow17) | physical | the NWS's SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it | must pass every probe that can ask it anything; **PASS**, 16 of 19, INCOMPLETE on the three energy-flux probes |
 | `reference_coupled` | exact | the bucket with snow sublimation and a surface energy budget: every kilogram converted at the latent heat of the phase it actually underwent | must pass every criterion of the three energy-flux probes; supports daily and hourly steps |
 | `reference_two_head` | broken | a water head and an energy head that never meet: both budgets close to 1e-15 and the latent heat implies an evaporation it never reported | caught by `flux_identity` |
 | `reference_constant_lambda` | broken | coherent, but converts every kilogram at the same latent heat of vaporisation | caught by `flux_identity` |
@@ -307,7 +308,7 @@ where that conversation happens, before and alongside the issues.
 
 ## Status
 
-Suite `0.1.0`, pre-release. Eighteen probes, thirteen mass, four energy, one momentum, synthetic track only. More
+Suite `0.1.0`, pre-release. Nineteen probes, fourteen mass, four energy, one momentum, synthetic track only. More
 energy and momentum probes, and the real-data track, are next. The harness runs paired cases and
 scores labelled regimes, so the generalisation probes on the roadmap —
 extrapolation in space and time, counterfactual response, invariance — are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,18 +153,13 @@ one, which is the deployment case the field actually cares about. The work is
 in defending where the hull boundary sits; push one attribute out at a time,
 or you generate catchments no real place resembles and fail honest models.
 
-### `mass/precipitation-counterfactual` &middot; standard &middot; **unclaimed**
-`ht init-probe --template counterfactual`
-
-The same seed twice, once wetter. The added water must appear in the
-difference between the reported budgets, split across evaporation, runoff and
-storage.
-
-*Discriminates:* closure by construction, structurally rather than
-circumstantially. A model that solves for a budget term as the residual closes
-perfectly on every seed forever, and today only its storage bounds catch it. A
-counterfactual asks where the extra water went, which construction cannot
-answer.
+### `mass/precipitation-counterfactual` &middot; **merged**
+The same seed 20% wetter, 10% wetter and 20% drier: the water added or
+removed must be partitioned among evaporation, runoff and storage, no term
+may ignore or absorb it, and runoff must rise from drier to wetter. Catches
+closure by construction: `reference_cheater` closes exactly on every seed,
+yet its evaporation does not respond to added rain.
+Contributed by Qingyi Yang (Politecnico di Milano).
 
 ### `mass/time-origin-invariance` &middot; **merged**
 By Siavash Shams. The same weather under a 28-year calendar shift that

--- a/docs/writing-a-probe.md
+++ b/docs/writing-a-probe.md
@@ -98,7 +98,7 @@ Every one is binary.
 | `non_degenerate` | the partition and the response are non-trivial | one run |
 | `forcing_fidelity` | the model reports back the forcing it was given | one run |
 | `regime_transfer` | closure holds out of range as well as in range | labelled stretches |
-| `counterfactual_response` | added water is partitioned, not absorbed | paired runs |
+| `counterfactual_response` | added or removed water is partitioned, not absorbed; `perturbed` may name one variant or a list, each scored against the control | paired runs |
 | `invariance` | a transform the physics ignores changes nothing | paired runs |
 | `resolution_invariance` | integrated volumes agree between the same weather at two steps | paired runs at different steps |
 | `response_sign` | perturb one driver both ways, hold the rest: each response must point the way physics says, by a real share of the change in demand | paired runs |
@@ -233,8 +233,8 @@ The reference models available today:
 | `flex_lumped` | lumped FLEX/HBV from chrimerss/HydrologicModels; conservative, nonlinear partition | nothing, it must pass |
 | `flex_topo` | FLEX-Topo, three landscape units sharing a groundwater store | nothing, it must pass |
 | `sacsma_snow17` | SAC-SMA + Snow-17 + gamma unit hydrograph, the NWS operational model | nothing, it must pass |
-| `reference_leaky` | hides a silent 15% sink | `closure` |
-| `reference_cheater` | solves for storage as whatever balances the budget; runoff is a fixed share of rain | `state_bounds`, `response_sign` |
+| `reference_leaky` | hides a silent 15% sink | `closure`, `counterfactual_response` |
+| `reference_cheater` | solves for storage as whatever balances the budget; runoff is a fixed share of rain | `state_bounds`, `response_sign`, `counterfactual_response` |
 | `reference_degenerate` | evaporates all precipitation, produces no runoff | `non_degenerate`, `counterfactual_response`, `response_sign` |
 | `reference_in_sample` | exact in range, leaks outside it | `regime_transfer` |
 | `reference_calendar` | recession drifts with the calendar year | `invariance` |

--- a/models/result.csv
+++ b/models/result.csv
@@ -196,3 +196,8 @@ run_date,model,version,suite_version,runner,probe,verdict,reason,window,seeds,de
 2026-09-10,flex_lumped,1.0.0,0.1.0,subprocess,energy/surface-energy-closure,FAIL,INCOMPLETE,not run,,"does not report hfls, hfss, hfg"
 2026-09-10,flex_topo,1.0.0,0.1.0,subprocess,energy/surface-energy-closure,FAIL,INCOMPLETE,not run,,"does not report hfls, hfss, hfg"
 2026-09-10,sacsma_snow17,1.0.0,0.1.0,subprocess,energy/surface-energy-closure,FAIL,INCOMPLETE,not run,,"does not report hfls, hfss, hfg"
+2026-09-11,flex_lumped,1.0.0,0.1.0,subprocess,mass/precipitation-counterfactual,PASS,OK,full record,872466880 1379418994 1886371108,residual 0.000% of driver
+2026-09-11,flex_topo,1.0.0,0.1.0,subprocess,mass/precipitation-counterfactual,PASS,OK,full record,872466880 1379418994 1886371108,residual 0.000% of driver
+2026-09-11,sacsma_snow17,1.0.0,0.1.0,subprocess,mass/precipitation-counterfactual,PASS,OK,full record,872466880 1379418994 1886371108,residual 0.000% of driver
+2026-09-11,google_flood_forecast,0.1.0-828dfc5,0.1.0,docker,mass/precipitation-counterfactual,FAIL,INCOMPLETE,not run,,"does not report pr, evspsbl, mrso, snw, canopy"
+2026-09-11,dhbv2,0.5.4-hbv2ep100.3,0.1.0,docker,mass/precipitation-counterfactual,FAIL,VIOLATION,full record,872466880 1379418994 1886371108,"state_bounds: mrso leaves [0, 320] on 3650 steps (range 600 to 805)"

--- a/probes/mass/precipitation-counterfactual/README.md
+++ b/probes/mass/precipitation-counterfactual/README.md
@@ -1,0 +1,130 @@
+# mass/precipitation-counterfactual
+
+A model that reports one budget term as the residual of the others closes the water budget on every seed. This probe asks what construction cannot answer: when the same seed gets more or less rain, where did the difference go? It implements [accepted proposal #18](https://github.com/Flood-Lab/HydroTuring/issues/18). Every number below was measured with `ht run` and `ht gate` on the gate seeds (872466880, 1379418994, 1886371108) at upstream `273a5b2`.
+
+## What it asserts
+
+Over the scored window `W`, each perturbed variant `p` is compared with the control `c`, with `delta X = X_p - X_c`:
+
+```text
+P_v  = sum_W pr_v(t) dt          E_v = sum_W evspsbl_v(t) dt
+Q_v  = sum_W mrro_v(t) dt        G_v = sum_W gwex_v(t) dt      (zero when not reported)
+dS_v = S_v(end) - S_v(start-)    S   = every reported store
+R_v  = P_v + G_v - E_v - Q_v - dS_v                                       [mm]
+
+f_E = delta E / delta P     f_Q = delta Q / delta P
+f_S = delta dS / delta P    f_X = -delta G / delta P    (signed export of the increment)
+
+R_delta / delta P = 1 - (f_E + f_Q + f_S + f_X)                            [-]
+```
+
+`S_v(start-)` is the storage one row before the first scored row. The denominator is the precipitation added or removed, not the control total. For `drier20` it is negative, and each share is the fraction of the removed water that term gave up. These are incremental fractions, not elasticities; the measured elasticities (1.4 to 2.4) exceed one without violating anything.
+
+| Criterion | Variants | Asserts |
+| --- | --- | --- |
+| `closure` | control | `abs(R_c) / P_c <= 0.05`; `gwex` counted as a declared source |
+| `counterfactual_response` | control vs. each of wetter20, wetter10, drier20 | `f_E`, `f_Q` each `>= 0.03`; every share incl. `f_S` `<= 0.95`; `abs(f_E + f_Q + f_S - 1) <= 0.10`; any pair failing fails |
+| `monotone_response` | all four, sorted by total `pr` | runoff does not fall between adjacent rungs; no rung adds more runoff than rain (1.05, slack 0.01); at least 0.1 of the rain added across the ladder runs off |
+| `forcing_fidelity` | control | echoed `pr` equals the given `pr`, `rtol 1e-6` |
+| `state_bounds` | control | `mrso` in `[0, soil_capacity_mm]`, `canopy` in `[0, canopy_capacity_mm]`, `snw >= 0` |
+
+`counterfactual_response` leaves out `gwex`, so for `sacsma_snow17` the three-term sum is `1 - f_X`, with `f_X` measured at +0.0042 to +0.0049.
+
+| Setting | Value | Origin |
+| --- | --- | --- |
+| `closure` threshold | 0.05 of `sum_pr` | suite-wide rule; loose against model numerics (baselines close to 1.7e-16; time-stepping errors are the subject of [R11]), tight against observed closure, where residuals of 5% to 25% are typical [R9, R10] |
+| `min_share` / `sum_tolerance` | 0.03 / 0.10 | template defaults; no paper sets them, margins below |
+| `max_share` | 0.95 | template default 0.90, raised here; see below |
+| `monotone_response` 0.1 / 1.05 / 0.01 | as in `mass/extreme-rain` | criterion defaults; `0 <= dQ/dP <= 1` follows from Budyko [R6] and the budget |
+| `forcing_fidelity` `rtol`, `state_bounds` capacities | 1e-6, `static.json` | numerical, physical |
+| `min_window_days` | 3650 | measured, window table below |
+
+**Margins.** At +20% on the worst seed, evaporation reaches 0.140 against 0.03, runoff 0.839 against 0.95, and the sum 0.994 against 0.10. Seeds differ by at most 0.02 in any share.
+
+**Why 0.95.** The template's 0.90 leaves `sacsma_snow17` 0.061 of margin. In a wetter catchment near saturation the Budyko limit of the runoff share is one, so 0.90 would fail exact physics there. Here 0.95 changes no verdict.
+
+**A physical bracket.** No paper sets the share bounds, so Budyko supplies one. With Fu's curve [R7] and the sensitivities of [R6], at PET/P 0.876 to 0.960 and curve parameters 2.0 to 3.0, the expected runoff share is 0.65 to 0.75. The expected evaporation share is 0.25 to 0.35; the baselines measure 0.59 to 0.84 and 0.14 to 0.37. The bounds therefore belong to this catchment. Measured elasticities lie inside the observed ranges for the United States, 1.0 to 2.5 [R8], and Australia, 2.0 to 3.5 [R12].
+
+**The denominator cannot approach zero.** At +20% the added precipitation is 1589, 1634 and 1737 mm. Rounding to 1e-6 mm over 3650 rows leaves an arithmetic error of order 1e-2 mm, so no absolute floor is needed.
+
+## The case
+
+Each seed draws 4,015 daily rows: 365 of spinup and 3,650 scored. All random draws happen before the variant is applied. A variant multiplies the scored `pr` by 1.20, 1.10 or 0.80 and leaves `tas`, `pet`, wet-day occurrence, event order and the spinup untouched. Four variants is the schema's `maxItems`.
+
+The control carries 794 to 869 mm a year on 91 to 95 wet days. Mean wet-day depth is 8.7 to 9.1 mm, and the largest daily total 70 to 97 mm. PET/P of 0.876 to 0.960 places it near the middle of the Budyko curve. A third of the precipitation falls below 0 °C, so snow must be reported in `snw`; `flex_lumped` and `flex_topo` have no snow module and treat it as rain. Temporal concentration is held fixed because it changes storage on its own [R3].
+
+Shares (evaporation, runoff, storage) on the seed the harness reports as worst. Every cell passes the bounds:
+
+| Amplitude | reference_bucket | flex_lumped | flex_topo | sacsma_snow17 |
+| --- | --- | --- | --- | --- |
+| −20% | 0.372, 0.593, 0.034 | 0.240, 0.745, 0.014 | 0.263, 0.727, 0.010 | 0.236, 0.725, 0.033 |
+| −10% | 0.330, 0.660, 0.009 | 0.219, 0.767, 0.014 | 0.248, 0.742, 0.010 | 0.225, 0.737, 0.033 |
+| −5% | 0.291, 0.674, 0.034 | 0.210, 0.776, 0.014 | 0.242, 0.744, 0.015 | 0.215, 0.748, 0.033 |
+| +5% | 0.261, 0.712, 0.028 | 0.192, 0.786, 0.022 | 0.229, 0.757, 0.014 | 0.203, 0.760, 0.032 |
+| +10% | 0.243, 0.730, 0.028 | 0.186, 0.793, 0.022 | 0.210, 0.775, 0.016 | 0.159, 0.795, 0.041 |
+| +20% | 0.219, 0.754, 0.028 | 0.176, 0.811, 0.013 | 0.206, 0.784, 0.010 | 0.151, 0.803, 0.042 |
+| +50% | 0.196, 0.777, 0.028 | 0.164, 0.820, 0.017 | 0.177, 0.814, 0.009 | 0.128, 0.827, 0.042 |
+
+The runoff share rises smoothly with amplitude and model differences exceed seed differences. The runoff coefficient of `reference_bucket` goes from 0.41–0.43 to 0.47–0.49 at +20%, and `flex_topo` stays below 0.57, so ±20% keeps every baseline in its regime. The same ±20% grid in 10-point steps is used by [R1, section 3.2] and [R2, section 2.3.2].
+
+The response is monotone but not symmetric: `reference_bucket` returns 0.593 of the removed water as runoff at −20% and 0.754 of the added water at +20%. [R5] find the same asymmetry on 353 observed catchments, so the probe asks only for monotonicity. Across the whole ladder the baselines return 0.69 to 0.82 of the added rain as runoff.
+
+**The scoring window is the whole record.** A submitted daily model is scored by default on the largest 30-day flood event. A short window counts only the rain added inside it, while its runoff carries increment stored earlier:
+
+| Window | reference_bucket (E, Q, S) | sacsma_snow17 | Verdict |
+| --- | --- | --- | --- |
+| 30 days (default) | 0.000, 2.870, −1.870 | 0.000, 1.909, −0.911 | FAIL both |
+| 365 days | 0.164, 0.897, −0.061 | 0.158, 0.533, 0.308 | PASS, runoff 0.003 from the 0.90 limit |
+| 730 days | 0.168, 0.911, −0.079 | 0.108, 0.917, −0.030 | FAIL both, `max_share` |
+| 1825 days | passes | passes | PASS |
+| 3650 days (full) | 0.219, 0.754, 0.028 | 0.151, 0.803, 0.042 | PASS |
+
+The window follows the largest flood, so the sequence is not monotone in length. Sensitivity depends on aggregation time through storage [R4]; ten years is this probe's measured requirement, not a universal one. `mass/phase-counterfactual` uses the same mechanism at 1095 days.
+
+**Spinup.** One year is enough. Prepending 365 or 1460 days of independent weather moves the shares by at most 0.001, or 0.009 for `flex_topo`. Lengthening `SPINUP_DAYS` instead changes the scored weather and moves them by up to 0.05.
+
+## Why these criteria
+
+Closure alone is trivially satisfiable. Each other criterion closes off a specific cheat, measured here at +20%:
+
+| Criterion | The cheat it closes off | Caught here |
+| --- | --- | --- |
+| `closure` | a silent sink | `reference_leaky`, residual 15.0% |
+| `counterfactual_response` | ignoring the perturbation, giving it all to one term, or inventing water between two runs that each close | `reference_cheater` (E, Q, S = 0.000, 0.350, 0.650), `reference_degenerate` (1.000, 0.000, 0.000), `reference_leaky` (0.285, 0.542, 0.024; sum 0.850) |
+| `monotone_response` | runoff that falls as rain rises, or exceeds it | `reference_degenerate`, 0.00 returned across the ladder |
+| `forcing_fidelity` | rescaling the input to choose the denominator | |
+| `state_bounds` | storage invented as the residual | `reference_cheater`, `mrso` reaches 1870 mm |
+
+`reference_cheater` (`ET = 0.55 PET`, `Q = 0.35 P`, storage as the residual) closes exactly on every seed. `state_bounds` catches it only once its storage drifts out of range; `counterfactual_response` catches it regardless, because unchanged PET gives no evaporation response. All three broken models are pinned to `counterfactual_response` in `must_fail`.
+
+**Limits.**
+
+- `reference_in_sample` passes at every amplitude, with shares 0.219, 0.741, 0.028 and a sum of 0.977 to 0.987. Its loss needs daily rain above 55 mm, and +20% raises such days from 5–7 to 10–14 per record. The loss is 1.3% to 2.3% of the added water; tightening `sum_tolerance` to catch it would leave `sacsma_snow17` without margin.
+- A fixed-ratio reporter whose ratios fall inside the bounds passes without dynamics.
+- Equal and opposite errors inside one run cancel in a cumulative budget.
+- The bounds are measured for this climate (PET/P 0.88–0.96, a third of precipitation as snow) and must be re-measured for another.
+
+## Reproducing a failure
+
+Every run records its seed. To re-run one:
+
+```bash
+ht run --model <name> --probe mass/precipitation-counterfactual --seed <n>
+```
+
+`ht gate --probe mass/precipitation-counterfactual` runs twelve ten-year daily runs per model, about 2 s per model with the subprocess runner. `pytest -q tests/test_precipitation_counterfactual.py tests/test_counterfactual_response.py` covers the generator and the criterion.
+
+## References
+
+- R1. Rasouli, Pomeroy & Whitfield (2022), *J. Hydrol.* 606, 127460. https://doi.org/10.1016/j.jhydrol.2022.127460
+- R2. Li et al. (2024), *Hydrol. Earth Syst. Sci.* 28, 4521–4538. https://doi.org/10.5194/hess-28-4521-2024
+- R3. Lesk & Mankin (2026), *Nature* 653, 425–432. https://doi.org/10.1038/s41586-026-10487-7
+- R4. Zhang, Viglione & Blöschl (2022), *Water Resour. Res.* 58, e2021WR030601. https://doi.org/10.1029/2021WR030601
+- R5. Tang et al. (2019), *J. Geophys. Res. Atmos.* 124, 11932–11943. https://doi.org/10.1029/2018JD030129
+- R6. Roderick & Farquhar (2011), *Water Resour. Res.* 47, W00G07. https://doi.org/10.1029/2010WR009826
+- R7. Zhang et al. (2004), *Water Resour. Res.* 40, W02502. https://doi.org/10.1029/2003WR002710
+- R8. Sankarasubramanian, Vogel & Limbrunner (2001), *Water Resour. Res.* 37, 1771–1781. https://doi.org/10.1029/2000WR900330
+- R9. Sahoo et al. (2011), *Remote Sens. Environ.* 115, 1850–1865. https://doi.org/10.1016/j.rse.2011.03.009
+- R10. Lorenz et al. (2014), *J. Hydrometeorol.* 15, 2111–2139. https://doi.org/10.1175/JHM-D-13-0157.1
+- R11. Kavetski & Clark (2010), *Water Resour. Res.* 46, W10511. https://doi.org/10.1029/2009WR008896
+- R12. Chiew (2006), *Hydrol. Sci. J.* 51, 613–625. https://doi.org/10.1623/hysj.51.4.613

--- a/probes/mass/precipitation-counterfactual/README.md
+++ b/probes/mass/precipitation-counterfactual/README.md
@@ -37,7 +37,7 @@ R_delta / delta P = 1 - (f_E + f_Q + f_S + f_X)                            [-]
 | `max_share` | 0.95 | template default 0.90, raised here; see below |
 | `monotone_response` 0.1 / 1.05 / 0.01 | as in `mass/extreme-rain` | criterion defaults; `0 <= dQ/dP <= 1` follows from Budyko [R6] and the budget |
 | `forcing_fidelity` `rtol`, `state_bounds` capacities | 1e-6, `static.json` | numerical, physical |
-| `min_window_days` | 3650 | measured, window table below |
+| `min_window_days` | 3650 | conservative; 1825 days also passes every baseline, window table below |
 
 **Margins.** At +20% on the worst seed, evaporation reaches 0.140 against 0.03, runoff 0.839 against 0.95, and the sum 0.994 against 0.10. Seeds differ by at most 0.02 in any share.
 
@@ -69,17 +69,17 @@ The runoff share rises smoothly with amplitude and model differences exceed seed
 
 The response is monotone but not symmetric: `reference_bucket` returns 0.593 of the removed water as runoff at −20% and 0.754 of the added water at +20%. [R5] find the same asymmetry on 353 observed catchments, so the probe asks only for monotonicity. Across the whole ladder the baselines return 0.69 to 0.82 of the added rain as runoff.
 
-**The scoring window is the whole record.** A submitted daily model is scored by default on the largest 30-day flood event. A short window counts only the rain added inside it, while its runoff carries increment stored earlier:
+**The scoring window is the whole record.** A submitted daily model is scored by default on the largest 30-day flood event. A short window counts only the rain added inside it, while its runoff carries increment stored earlier. Verdicts with the shipped settings (`max_share` 0.95, all three pairs, gate seeds), naming the share that breaks:
 
-| Window | reference_bucket (E, Q, S) | sacsma_snow17 | Verdict |
-| --- | --- | --- | --- |
-| 30 days (default) | 0.000, 2.870, −1.870 | 0.000, 1.909, −0.911 | FAIL both |
-| 365 days | 0.164, 0.897, −0.061 | 0.158, 0.533, 0.308 | PASS, runoff 0.003 from the 0.90 limit |
-| 730 days | 0.168, 0.911, −0.079 | 0.108, 0.917, −0.030 | FAIL both, `max_share` |
-| 1825 days | passes | passes | PASS |
-| 3650 days (full) | 0.219, 0.754, 0.028 | 0.151, 0.803, 0.042 | PASS |
+| Window | reference_bucket | flex_lumped | flex_topo | sacsma_snow17 |
+| --- | --- | --- | --- | --- |
+| 30 days (default) | FAIL, runoff 2.870, storage −1.870 | FAIL, runoff 1.308 | FAIL, evaporation 0.013 | FAIL, runoff 1.053 |
+| 365 days | FAIL, `drier20` runoff 0.961 | PASS | PASS | PASS |
+| 730 days | PASS | PASS | PASS | FAIL, `wetter20` runoff 0.996 |
+| 1825 days | PASS | PASS | PASS | PASS |
+| 3650 days (full) | PASS | PASS | PASS | PASS |
 
-The window follows the largest flood, so the sequence is not monotone in length. Sensitivity depends on aggregation time through storage [R4]; ten years is this probe's measured requirement, not a universal one. `mass/phase-counterfactual` uses the same mechanism at 1095 days.
+The window follows the largest flood, so the sequence is not monotone in length: 365 days fails `reference_bucket` and 730 days fails `sacsma_snow17`. Sensitivity depends on aggregation time through storage [R4]. 1825 days passes all four baselines, so the full record is the conservative choice rather than the shortest window that works. `mass/phase-counterfactual` uses the same mechanism at 1095 days.
 
 **Spinup.** One year is enough. Prepending 365 or 1460 days of independent weather moves the shares by at most 0.001, or 0.009 for `flex_topo`. Lengthening `SPINUP_DAYS` instead changes the scored weather and moves them by up to 0.05.
 

--- a/probes/mass/precipitation-counterfactual/generate.py
+++ b/probes/mass/precipitation-counterfactual/generate.py
@@ -1,0 +1,75 @@
+"""Forcing generator for mass/precipitation-counterfactual: one seed, four rainfalls.
+
+The weather is drawn once per seed; a variant only scales the scored
+precipitation, so `tas`, `pet`, wet-day occurrence, event order and the
+spinup are shared exactly between variants.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+PERIOD_YEARS = 10
+SPINUP_DAYS = 365
+N_STEPS = int(PERIOD_YEARS * 365) + SPINUP_DAYS
+
+# Multiplier on the scored precipitation (README, amplitude table).
+PERTURBATION = {"control": 1.00, "wetter20": 1.20, "wetter10": 1.10, "drier20": 0.80}
+VARIANTS = tuple(PERTURBATION)
+
+STATIC = {
+    "area_km2": 250.0,
+    "soil_capacity_mm": 320.0,
+    "canopy_capacity_mm": 2.0,
+    "degree_day_factor_mm_per_C_day": 3.2,
+    "baseflow_coefficient": 0.006,
+    "snow_threshold_degC": 0.0,
+    "latitude_deg": 40.0,
+}
+
+
+def generate(seed: int, variant: str = "control") -> tuple[pd.DataFrame, dict]:
+    if variant not in VARIANTS:
+        raise ValueError(f"unknown variant {variant!r}; expected one of {VARIANTS}")
+
+    rng = np.random.default_rng(seed)
+    day = np.arange(N_STEPS)
+    doy = day % 365
+
+    # Every draw happens before the variant is applied.
+    p_wet = 0.25 + 0.12 * np.cos(2 * np.pi * (doy - 30) / 365)
+    wet = rng.random(N_STEPS) < p_wet
+    pr = np.where(wet, rng.gamma(shape=0.7, scale=13.0, size=N_STEPS), 0.0)
+
+    seasonal = 9.0 - 12.0 * np.cos(2 * np.pi * (doy - 15) / 365)
+    noise = np.zeros(N_STEPS)
+    innovation = rng.normal(0.0, 2.6, N_STEPS)
+    for t in range(1, N_STEPS):
+        noise[t] = 0.72 * noise[t - 1] + innovation[t]
+    tas = seasonal + noise
+
+    daylength = 1.0 + 0.35 * np.cos(2 * np.pi * (doy - 172) / 365)
+    pet = np.maximum(0.0, 0.13 * (tas + 5.0)) * daylength
+
+    # Scale depths in the scored window only: every variant enters it from
+    # the same state, and occurrence and timing are held fixed.
+    pr[SPINUP_DAYS:] *= PERTURBATION[variant]
+
+    time = pd.date_range("2000-01-01", periods=N_STEPS, freq="D")
+    forcing = pd.DataFrame(
+        {
+            "time": time.strftime("%Y-%m-%d"),
+            "pr": np.round(pr, 6),
+            "tas": np.round(tas, 6),
+            "pet": np.round(pet, 6),
+        }
+    )
+    return forcing, dict(STATIC)
+
+
+if __name__ == "__main__":
+    control = generate(20260903)[0]["pr"][SPINUP_DAYS:].sum()
+    for variant in VARIANTS:
+        scored = generate(20260903, variant)[0]["pr"][SPINUP_DAYS:].sum()
+        print(f"{variant:9s} {scored / PERIOD_YEARS:6.0f} mm/yr  ({scored - control:+.0f} mm)")

--- a/probes/mass/precipitation-counterfactual/probe.yaml
+++ b/probes/mass/precipitation-counterfactual/probe.yaml
@@ -1,0 +1,93 @@
+id: mass/precipitation-counterfactual
+
+title: Added or removed precipitation must be partitioned among the budget terms
+
+law: mass
+track: synthetic
+version: 1
+
+authors:
+  - name: Qingyi Yang
+    affiliation: Department of Civil and Environmental Engineering (D.I.C.A.), Politecnico di Milano, Milano 20133, Italy
+    orcid: 0009-0001-9836-4261
+    github: yqingypolimi
+
+description: >
+  The same seed four times after an identical spinup: as generated, with
+  every scored wet day 20% wetter, 10% wetter, and 20% drier. The water
+  added or removed between a perturbed run and the control must appear in
+  the difference between the reported budgets, split across evaporation,
+  runoff and storage: no term may ignore it, no term may absorb it, and the
+  shares must sum to what was added. Runoff must rise monotonically along
+  the ladder from drier to wetter. Scored over the full ten-year record.
+
+requires:
+  fluxes: [pr, evspsbl, mrro]
+  states: [mrso, snw, canopy]
+
+case:
+  generator: generate.py
+  n_seeds: 3
+  timestep: PT1D
+  period_years: 10
+  spinup_days: 365
+  max_output_mb: 2.0
+  max_runtime_s: 60
+  # 30- and 730-day windows fail the exact physical models (README, window table).
+  min_window_days: 3650
+  # The first name is the control.
+  variants: [control, wetter20, wetter10, drier20]
+
+criteria:
+  # Suite-wide rule; the physical baselines close to 1e-16 here.
+  - closure:
+      denominator: sum_pr
+      threshold: 0.05
+      sinks: [evspsbl, mrro]
+
+  # Each perturbed variant is scored against the control; any pair failing
+  # fails. `storage` counts towards max_share and the sum, not min_share.
+  # min_share and sum_tolerance are template defaults (measured margins
+  # 0.140 and 0.994); max_share is raised from 0.90 because the Budyko limit
+  # of the runoff share is one, and changes no verdict here (README).
+  - counterfactual_response:
+      control: control
+      perturbed: [wetter20, wetter10, drier20]
+      driver: pr
+      terms: [evspsbl, mrro]
+      min_share: 0.03
+      max_share: 0.95
+      sum_tolerance: 0.10
+
+  # Every denominator above is the pr the model was given.
+  - forcing_fidelity:
+      variables: [pr]
+      rtol: 1.0e-6
+
+  # Criterion defaults, as in mass/extreme-rain; measured ladder returns 0.69 to 0.82.
+  - monotone_response:
+      driver: pr
+      variable: mrro
+      min_share: 0.1
+      max_share: 1.05
+      tolerance: 0.01
+
+  - state_bounds:
+      mrso: [0.0, soil_capacity_mm]
+      snw: [0.0, null]
+      canopy: [0.0, canopy_capacity_mm]
+
+baselines:
+  must_pass: [reference_bucket, flex_lumped, flex_topo, sacsma_snow17]
+  must_fail:
+    # Evaporates everything: runoff share 0, evaporation share 1.
+    reference_degenerate: counterfactual_response
+    # Storage as the residual: evaporation does not respond to added rain.
+    reference_cheater: counterfactual_response
+    # 15% of the rain leaves unreported: the shares sum to 0.85.
+    reference_leaky: counterfactual_response
+
+provenance: >
+  Synthetic. All four variants are generated at run time from one recorded
+  seed, so they differ only in the scored precipitation. Built from the
+  upstream counterfactual template; implements accepted proposal #18.

--- a/probes/mass/precipitation-counterfactual/probe.yaml
+++ b/probes/mass/precipitation-counterfactual/probe.yaml
@@ -33,7 +33,8 @@ case:
   spinup_days: 365
   max_output_mb: 2.0
   max_runtime_s: 60
-  # 30- and 730-day windows fail the exact physical models (README, window table).
+  # 30-, 365- and 730-day windows each fail a physical model; 1825 passes all
+  # four, and the full record is the conservative choice (README, window table).
   min_window_days: 3650
   # The first name is the control.
   variants: [control, wetter20, wetter10, drier20]

--- a/site/index.html
+++ b/site/index.html
@@ -274,30 +274,32 @@ a:focus-visible,button:focus-visible{outline:2px solid var(--accent); outline-of
       <line x1="284" y1="160" x2="352" y2="160" stroke="var(--line)"/>
       <circle cx="288" cy="169.5" r="2.4" fill="var(--pass)"/>
       <text x="296" y="173" class="probe" data-i18n="infra.probe.closure">closure</text>
-      <circle cx="288" cy="183.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="187" class="probe" data-i18n="infra.probe.resolution">resolution</text>
-      <circle cx="288" cy="197.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="201" class="probe" data-i18n="infra.probe.warming">warming</text>
-      <circle cx="288" cy="211.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="215" class="probe" data-i18n="infra.probe.causality">causality</text>
-      <circle cx="288" cy="225.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="229" class="probe" data-i18n="infra.probe.drydown">dry-down</text>
-      <circle cx="288" cy="239.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="243" class="probe" data-i18n="infra.probe.steady">steady state</text>
-      <circle cx="288" cy="253.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="257" class="probe" data-i18n="infra.probe.extreme">extreme rain</text>
-      <circle cx="288" cy="267.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="271" class="probe" data-i18n="infra.probe.runoffbounds">bounds</text>
-      <circle cx="288" cy="281.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="285" class="probe" data-i18n="infra.probe.area">area</text>
-      <circle cx="288" cy="295.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="299" class="probe" data-i18n="infra.probe.nonneg">nonnegative</text>
-      <circle cx="288" cy="309.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="313" class="probe" data-i18n="infra.probe.antecedent">antecedent</text>
-      <circle cx="288" cy="323.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="327" class="probe" data-i18n="infra.probe.phase">phase</text>
-      <circle cx="288" cy="337.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="341" class="probe" data-i18n="infra.probe.timeorigin">time origin</text>
+      <circle cx="288" cy="182.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="186" class="probe" data-i18n="infra.probe.resolution">resolution</text>
+      <circle cx="288" cy="195.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="199" class="probe" data-i18n="infra.probe.warming">warming</text>
+      <circle cx="288" cy="208.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="212" class="probe" data-i18n="infra.probe.causality">causality</text>
+      <circle cx="288" cy="221.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="225" class="probe" data-i18n="infra.probe.drydown">dry-down</text>
+      <circle cx="288" cy="234.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="238" class="probe" data-i18n="infra.probe.steady">steady state</text>
+      <circle cx="288" cy="247.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="251" class="probe" data-i18n="infra.probe.extreme">extreme rain</text>
+      <circle cx="288" cy="260.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="264" class="probe" data-i18n="infra.probe.runoffbounds">bounds</text>
+      <circle cx="288" cy="273.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="277" class="probe" data-i18n="infra.probe.area">area</text>
+      <circle cx="288" cy="286.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="290" class="probe" data-i18n="infra.probe.nonneg">nonnegative</text>
+      <circle cx="288" cy="299.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="303" class="probe" data-i18n="infra.probe.antecedent">antecedent</text>
+      <circle cx="288" cy="312.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="316" class="probe" data-i18n="infra.probe.phase">phase</text>
+      <circle cx="288" cy="325.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="329" class="probe" data-i18n="infra.probe.timeorigin">time origin</text>
+      <circle cx="288" cy="338.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="342" class="probe" data-i18n="infra.probe.rainladder">rain ±20%</text>
       <rect x="372" y="100" width="92" height="250" rx="6" fill="var(--surface-2)"/>
       <text x="418" y="121" class="pillar" data-i18n="infra.energy" text-anchor="middle">ENERGY</text>
       <text x="418" y="138" class="note" data-i18n="infra.energy.s1" text-anchor="middle">energy budget</text>
@@ -613,6 +615,7 @@ en: {
   "infra.probe.antecedent":"antecedent",
   "infra.probe.phase":"phase",
   "infra.probe.timeorigin":"time origin",
+  "infra.probe.rainladder":"rain ±20%",
   "infra.probe.pet":"PET demand",
   "infra.probe.latent":"latent heat",
   "infra.probe.partition":"partition",
@@ -660,11 +663,11 @@ en: {
   "models.th5":"Verdict",
   "models.intro":"<p>Every model that has been run against the suite. A submitted model is evaluated in an isolated container on a flood-event window of each probe's generated record. A physical model is one the acceptance gate requires every probe to pass; it is evaluated the same way, and a probe that fails one is examined before the model is.</p>",
   "models.legend":"<p>Every evaluation is appended to <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>, with the probe, the window, the seeds and the worst criterion. The verdict is one bit and its reason; the numbers under it are in the archive and in each model's README. To submit a model, open a <a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">model submission</a>.</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>submitted</td><td>Google Flood Hub's mean-embedding forecast LSTM, through OpenHydroNet with the published weights. Discharge only.</td><td>5 / 18</td><td><span class="tag incomplete">FAIL (INCOMPLETE)</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>submitted</td><td>δHBV 2.0, the MHPI differentiable HBV: networks write the parameters of a bucket model that reports its stores, its evaporation and, declared, its regional groundwater exchange.</td><td>11 / 18</td><td><span class="tag violation">FAIL (VIOLATION)</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>physical</td><td>Lumped FLEX/HBV from chrimerss/HydrologicModels: interception, beta-partitioned soil, fast and slow reservoirs, a lag.</td><td>15 / 18</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
-<tr><td class="mono">flex_topo</td><td>physical</td><td>FLEX-Topo: plateau, hillslope and wetland units on the Wark catchment's real fractions, sharing one groundwater store.</td><td>15 / 18</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>physical</td><td>The NWS operational SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it.</td><td>15 / 18</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>submitted</td><td>Google Flood Hub's mean-embedding forecast LSTM, through OpenHydroNet with the published weights. Discharge only.</td><td>5 / 19</td><td><span class="tag incomplete">FAIL (INCOMPLETE)</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>submitted</td><td>δHBV 2.0, the MHPI differentiable HBV: networks write the parameters of a bucket model that reports its stores, its evaporation and, declared, its regional groundwater exchange.</td><td>11 / 19</td><td><span class="tag violation">FAIL (VIOLATION)</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>physical</td><td>Lumped FLEX/HBV from chrimerss/HydrologicModels: interception, beta-partitioned soil, fast and slow reservoirs, a lag.</td><td>16 / 19</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>physical</td><td>FLEX-Topo: plateau, hillslope and wetland units on the Wark catchment's real fractions, sharing one groundwater store.</td><td>16 / 19</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>physical</td><td>The NWS operational SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it.</td><td>16 / 19</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
 `,
   "probes.h":"The probes",
   "probes.intro":"<p>Every probe in the suite, and every one the roadmap is waiting for. A merged probe is in the repository and passes the acceptance gate against the reference models. A wanted probe is named, unclaimed, and yours to take.</p>",
@@ -686,6 +689,7 @@ en: {
 <tr><td class="mono">mass/antecedent-monotonicity</td><td>mass</td><td>The same storm after a dry month and a wet one: more runoff from the wet one, no more than the extra water.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">mass/phase-counterfactual</td><td>mass</td><td>The same water as rain instead of snow: timing moves, the integrated volumes do not.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">mass/time-origin-invariance</td><td>mass</td><td>The same weather dated from another year must change nothing.</td><td><span class="tag merged">merged</span></td></tr>
+<tr><td class="mono">mass/precipitation-counterfactual</td><td>mass</td><td>The same seed wetter and drier: the water added or removed must be partitioned, and runoff must rise with rain.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">energy/pet-consistency</td><td>energy</td><td>Evaporation reaches demand when the model's own soil is wettest, never exceeds it, and falls when driest.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>energy</td><td>The evaporation a model reports as water and the one implied by its latent heat: are they the same evaporation?</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>energy</td><td>One summer without rain under radiation that did not change: the latent heat a drying surface gives up has to warm the air.</td><td><span class="tag merged">merged</span></td></tr>
@@ -698,7 +702,6 @@ en: {
 <tr><td class="mono">mass/human-abstraction</td><td>mass</td><td>Irrigation withdrawal and return flow must both appear in the budget.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/extreme-event-closure</td><td>mass</td><td>Closure through a storm outside anything earlier in the record.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>mass</td><td>Closure on catchments outside the range models are fitted to.</td><td><span class="tag wanted">wanted</span></td></tr>
-<tr><td class="mono">mass/precipitation-counterfactual</td><td>mass</td><td>Add water to the same case and ask where it went.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>energy</td><td>The full snowpack energy budget, cold content and phase change included.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">energy/radiation-consistency</td><td>energy</td><td>Outgoing longwave must be consistent with the reported surface temperature.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">momentum/channel-routing-mass</td><td>momentum</td><td>Inflow minus outflow minus the change in channel storage, per reach.</td><td><span class="tag wanted">wanted</span></td></tr>
@@ -810,6 +813,7 @@ es: {
   "infra.probe.antecedent":"antecedente",
   "infra.probe.phase":"fase",
   "infra.probe.timeorigin":"año inicial",
+  "infra.probe.rainladder":"lluvia ±20%",
   "infra.probe.pet":"demanda",
   "infra.probe.latent":"calor latente",
   "infra.probe.partition":"partición",
@@ -857,11 +861,11 @@ es: {
   "models.th5":"Veredicto",
   "models.intro":"<p>Todos los modelos que se han ejecutado contra la batería. Un modelo enviado se evalúa en un contenedor aislado sobre una ventana de crecida del registro generado de cada prueba. Un modelo físico es uno que la compuerta de aceptación exige que toda prueba supere; se evalúa igual, y una prueba que lo falla se examina antes que el modelo.</p>",
   "models.legend":"<p>Cada evaluación se añade a <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>, con la prueba, la ventana, las semillas y el peor criterio. El veredicto es un bit y su razón; los números están en el archivo y en el README de cada modelo. Para enviar un modelo, abre un <a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">envío de modelo</a>.</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>enviado</td><td>El LSTM de pronóstico de Google Flood Hub, vía OpenHydroNet con los pesos publicados. Solo caudal.</td><td>5 / 18</td><td><span class="tag incomplete">FALLA (INCOMPLETO)</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>enviado</td><td>δHBV 2.0, el HBV diferenciable de MHPI: redes que escriben los parámetros de un modelo de cubetas que reporta sus almacenes, su evaporación y, declarado, su intercambio regional de agua subterránea.</td><td>11 / 18</td><td><span class="tag violation">FALLA (VIOLACIÓN)</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>físico</td><td>FLEX/HBV agregado de chrimerss/HydrologicModels: intercepción, suelo con partición beta, embalses rápido y lento, un retardo.</td><td>15 / 18</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
-<tr><td class="mono">flex_topo</td><td>físico</td><td>FLEX-Topo: unidades de meseta, ladera y humedal con las fracciones reales de la cuenca Wark, un solo almacén subterráneo.</td><td>15 / 18</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>físico</td><td>El SAC-SMA operativo del NWS con Snow-17 y un hidrograma unitario gamma, portado del Fortran heredado y verificado contra él.</td><td>15 / 18</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>enviado</td><td>El LSTM de pronóstico de Google Flood Hub, vía OpenHydroNet con los pesos publicados. Solo caudal.</td><td>5 / 19</td><td><span class="tag incomplete">FALLA (INCOMPLETO)</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>enviado</td><td>δHBV 2.0, el HBV diferenciable de MHPI: redes que escriben los parámetros de un modelo de cubetas que reporta sus almacenes, su evaporación y, declarado, su intercambio regional de agua subterránea.</td><td>11 / 19</td><td><span class="tag violation">FALLA (VIOLACIÓN)</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>físico</td><td>FLEX/HBV agregado de chrimerss/HydrologicModels: intercepción, suelo con partición beta, embalses rápido y lento, un retardo.</td><td>16 / 19</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>físico</td><td>FLEX-Topo: unidades de meseta, ladera y humedal con las fracciones reales de la cuenca Wark, un solo almacén subterráneo.</td><td>16 / 19</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>físico</td><td>El SAC-SMA operativo del NWS con Snow-17 y un hidrograma unitario gamma, portado del Fortran heredado y verificado contra él.</td><td>16 / 19</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
 `,
   "probes.h":"Las pruebas",
   "probes.intro":"<p>Todas las pruebas de la batería, y todas las que la hoja de ruta espera. Una prueba integrada está en el repositorio y supera la compuerta de aceptación frente a los modelos de referencia. Una prueba que se busca tiene nombre, nadie la ha reclamado, y es tuya si la tomas.</p>",
@@ -883,6 +887,7 @@ es: {
 <tr><td class="mono">mass/antecedent-monotonicity</td><td>masa</td><td>La misma tormenta tras un mes seco y tras uno húmedo: más escorrentía en el húmedo, y no más que el agua extra.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">mass/phase-counterfactual</td><td>masa</td><td>La misma agua como lluvia en vez de nieve: cambia el momento, no los volúmenes integrados.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">mass/time-origin-invariance</td><td>masa</td><td>El mismo clima fechado desde otro año no debe cambiar nada.</td><td><span class="tag merged">integrada</span></td></tr>
+<tr><td class="mono">mass/precipitation-counterfactual</td><td>masa</td><td>La misma semilla más húmeda y más seca: el agua añadida o retirada debe repartirse, y la escorrentía debe crecer con la lluvia.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">energy/pet-consistency</td><td>energía</td><td>La evaporación alcanza la demanda cuando el suelo del propio modelo está más húmedo, nunca la supera y baja cuando está más seco.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>energía</td><td>La evaporación que un modelo reporta como agua y la que implica su calor latente: ¿son la misma evaporación?</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>energía</td><td>Un verano sin lluvia bajo una radiación que no cambió: el calor latente que cede una superficie que se seca tiene que calentar el aire.</td><td><span class="tag merged">integrada</span></td></tr>
@@ -895,7 +900,6 @@ es: {
 <tr><td class="mono">mass/human-abstraction</td><td>masa</td><td>La extracción para riego y el retorno deben aparecer ambos en el balance.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/extreme-event-closure</td><td>masa</td><td>Cierre durante una tormenta fuera de todo lo anterior en el registro.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>masa</td><td>Cierre en cuencas fuera del rango al que se ajustan los modelos.</td><td><span class="tag wanted">se busca</span></td></tr>
-<tr><td class="mono">mass/precipitation-counterfactual</td><td>masa</td><td>Añadir agua al mismo caso y preguntar adónde fue.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>energía</td><td>El balance energético completo del manto de nieve, con contenido frío y cambio de fase.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">energy/radiation-consistency</td><td>energía</td><td>La onda larga saliente debe ser coherente con la temperatura superficial reportada.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">momentum/channel-routing-mass</td><td>momento</td><td>Entrada menos salida menos el cambio de almacenamiento en el cauce, por tramo.</td><td><span class="tag wanted">se busca</span></td></tr>
@@ -1007,6 +1011,7 @@ zh: {
   "infra.probe.antecedent":"前期湿度",
   "infra.probe.phase":"相态",
   "infra.probe.timeorigin":"时间起点",
+  "infra.probe.rainladder":"降水 ±20%",
   "infra.probe.pet":"蒸散需求",
   "infra.probe.latent":"潜热一致",
   "infra.probe.partition":"能量分配",
@@ -1054,11 +1059,11 @@ zh: {
   "models.th5":"结论",
   "models.intro":"<p>所有已在本套件上运行过的模型。提交模型在隔离容器中，于每个检验项生成记录的洪水事件窗口上评估。物理模型是验收闸门要求每个检验项都必须通过的模型，以同样方式评估；若某检验项未能通过物理模型，先检查检验项，再检查模型。</p>",
   "models.legend":"<p>每次评估都会追加到 <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>，记录检验项、窗口、种子与最差准则。结论是一个比特及其原因；其下的数字在归档和各模型的 README 中。提交模型请打开<a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">模型提交</a>。</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>提交模型</td><td>Google Flood Hub 的均值嵌入预报 LSTM，经 OpenHydroNet 以公开权重运行。仅输出流量。</td><td>5 / 18</td><td><span class="tag incomplete">未通过（信息不全）</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>提交模型</td><td>δHBV 2.0，MHPI 的可微 HBV：神经网络写出水桶模型的参数，模型报告蓄水、蒸发，并申报其区域地下水交换。</td><td>11 / 18</td><td><span class="tag violation">未通过（违反）</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>物理模型</td><td>来自 chrimerss/HydrologicModels 的集总 FLEX/HBV：截留、beta 分配的土壤、快慢水库与滞时。</td><td>15 / 18</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
-<tr><td class="mono">flex_topo</td><td>物理模型</td><td>FLEX-Topo：台地、坡地与湿地单元按 Wark 流域的真实面积比共享一个地下水库。</td><td>15 / 18</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>物理模型</td><td>美国国家气象局业务用 SAC-SMA + Snow-17 + 伽马单位线，由遗留 Fortran 移植并与之比对。</td><td>15 / 18</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>提交模型</td><td>Google Flood Hub 的均值嵌入预报 LSTM，经 OpenHydroNet 以公开权重运行。仅输出流量。</td><td>5 / 19</td><td><span class="tag incomplete">未通过（信息不全）</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>提交模型</td><td>δHBV 2.0，MHPI 的可微 HBV：神经网络写出水桶模型的参数，模型报告蓄水、蒸发，并申报其区域地下水交换。</td><td>11 / 19</td><td><span class="tag violation">未通过（违反）</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>物理模型</td><td>来自 chrimerss/HydrologicModels 的集总 FLEX/HBV：截留、beta 分配的土壤、快慢水库与滞时。</td><td>16 / 19</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>物理模型</td><td>FLEX-Topo：台地、坡地与湿地单元按 Wark 流域的真实面积比共享一个地下水库。</td><td>16 / 19</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>物理模型</td><td>美国国家气象局业务用 SAC-SMA + Snow-17 + 伽马单位线，由遗留 Fortran 移植并与之比对。</td><td>16 / 19</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
 `,
   "probes.h":"检验项一览",
   "probes.intro":"<p>套件中的每一项检验，以及路线图正在等待的每一项。已合并的检验项已在仓库中，并在参照模型上通过验收闸门。征集中的检验项已有名字、尚无人认领，欢迎认领。</p>",
@@ -1080,6 +1085,7 @@ zh: {
 <tr><td class="mono">mass/antecedent-monotonicity</td><td>质量</td><td>同一场暴雨，分别落在干月与湿月之后：湿的流域径流更多，且不超过多出的水量。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">mass/phase-counterfactual</td><td>质量</td><td>同样的水以雨而非雪的形式落下：时间会变，积分体积不变。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">mass/time-origin-invariance</td><td>质量</td><td>同样的天气换个年份，结果不得改变。</td><td><span class="tag merged">已合并</span></td></tr>
+<tr><td class="mono">mass/precipitation-counterfactual</td><td>质量</td><td>同一种子加雨与减雨：增减的水必须被分配，径流须随雨量上升。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">energy/pet-consistency</td><td>能量</td><td>当模型自身土壤最湿时蒸发达到需求、永不超过需求，最干时蒸发下降。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>能量</td><td>模型作为水量报告的蒸发与其潜热通量所隐含的蒸发：是否是同一个蒸发？</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>能量</td><td>净辐射不变的情况下一个无雨的夏天：干燥地表让出的潜热必须去加热空气。</td><td><span class="tag merged">已合并</span></td></tr>
@@ -1092,7 +1098,6 @@ zh: {
 <tr><td class="mono">mass/human-abstraction</td><td>质量</td><td>灌溉取水与回归水都必须出现在收支中。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/extreme-event-closure</td><td>质量</td><td>在超出历史记录的暴雨中保持闭合。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>质量</td><td>在模型拟合范围之外的流域上保持闭合。</td><td><span class="tag wanted">征集中</span></td></tr>
-<tr><td class="mono">mass/precipitation-counterfactual</td><td>质量</td><td>向同一案例加水，追问水去了哪里。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>能量</td><td>完整的积雪能量收支，含冷储量与相变。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">energy/radiation-consistency</td><td>能量</td><td>出射长波辐射必须与所报告的地表温度一致。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">momentum/channel-routing-mass</td><td>动量</td><td>逐河段：入流减出流减河道蓄量变化。</td><td><span class="tag wanted">征集中</span></td></tr>

--- a/src/hydroturing/criteria/response.py
+++ b/src/hydroturing/criteria/response.py
@@ -15,6 +15,9 @@ The three failure modes this separates:
   the shares do not sum   the model invents or destroys water in the
                           difference between the two runs, even though each
                           run closes on its own
+
+A probe may pair several perturbed variants with one control, and a variant
+may remove water as well as add it; each pair is scored on its own.
 """
 
 from __future__ import annotations
@@ -33,9 +36,8 @@ from hydroturing.protocol import RunResult
 from hydroturing.spec import ProbeSpec
 
 
-def pick(runs: dict[str, RunResult], params: dict, key: str, default: str) -> RunResult:
-    """Resolve a variant named in the probe to the run the model produced for it."""
-    name = str(params.get(key, default))
+def lookup(runs: dict[str, RunResult], name: str, key: str) -> RunResult:
+    """The run the model produced for a variant named under `key` in the probe."""
     if name not in runs:
         raise ValueError(
             f"variant '{name}' is not one of this probe's variants "
@@ -45,90 +47,125 @@ def pick(runs: dict[str, RunResult], params: dict, key: str, default: str) -> Ru
     return runs[name]
 
 
+def pick(runs: dict[str, RunResult], params: dict, key: str, default: str) -> RunResult:
+    """Resolve a variant named in the probe to the run the model produced for it."""
+    return lookup(runs, str(params.get(key, default)), key)
+
+
 @criterion("counterfactual_response", paired=True)
 def counterfactual_response(
     runs: dict[str, RunResult], probe: ProbeSpec, params: dict
 ) -> CriterionResult:
-    """Added water must be partitioned, and no single term may take it all."""
+    """Added or removed water must be partitioned, and no single term may take it all.
+
+    `perturbed` names one variant or a list of them. Each is scored against
+    the control on its own, with the same three checks, and any failing pair
+    fails the criterion; the value reported is the pair whose accounted sum
+    sits farthest from one. A variant that removes water divides by a
+    negative change in the driver, so the shares keep their meaning: the
+    fraction of the removed water each term gave up.
+    """
     driver = str(params.get("driver", "pr"))
     terms = list(params.get("terms", ["evspsbl", "mrro"]))
     min_share = float(params.get("min_share", 0.05))
     max_share = float(params.get("max_share", 0.90))
     sum_tolerance = float(params.get("sum_tolerance", 0.10))
+    names = params.get("perturbed", "perturbed")
+    if isinstance(names, str):
+        names = [names]
+    several = len(names) > 1
 
     control = make_window(pick(runs, params, "control", "control"), probe)
-    perturbed = make_window(pick(runs, params, "perturbed", "perturbed"), probe)
-
     if driver not in control.forcing.columns:
         raise ValueError(f"counterfactual_response needs '{driver}' in the forcing")
-
-    added = float(
-        perturbed.volume(perturbed.forcing[driver]).sum()
-        - control.volume(control.forcing[driver]).sum()
-    )
-    if added <= 0:
-        raise ValueError(
-            f"the perturbed variant adds no {driver} ({added:.4g} mm); the "
-            "generator has to make the two variants actually differ"
-        )
-
-    shares: dict[str, float] = {}
     for var in terms:
         if var not in control.table.columns:
             raise ValueError(f"counterfactual_response needs '{var}' in the model result")
-        change = float(
-            perturbed.volume(perturbed.table[var]).sum()
-            - control.volume(control.table[var]).sum()
-        )
-        shares[var] = change / added
-
     states = reported_states(control, probe)
-    if states:
-        def storage_change(w):
-            return float(w.storage(states)[-1]) - w.storage_initial(states)
 
-        shares["storage"] = (storage_change(perturbed) - storage_change(control)) / added
+    def storage_change(w):
+        return float(w.storage(states)[-1]) - w.storage_initial(states)
 
-    failures = []
-    for var, share in shares.items():
-        if var == "storage":
-            continue
-        if abs(share) < min_share:
-            failures.append(
-                f"{var} barely responds ({share:+.3f} of the added {driver}, "
-                f"minimum {min_share:g})"
+    def sign_word(mm):
+        return "added" if mm > 0 else "removed"
+
+    # The control side of every difference, summed once.
+    control_driver = control.volume(control.forcing[driver]).sum()
+    control_terms = {var: control.volume(control.table[var]).sum() for var in terms}
+    control_storage = storage_change(control) if states else 0.0
+
+    per_variant: dict[str, dict] = {}
+    failures: list[str] = []
+    for name in names:
+        perturbed = make_window(lookup(runs, name, "perturbed"), probe)
+        if len(perturbed.table) != len(control.table):
+            raise ValueError(
+                f"variant '{name}' produced a window of a different length "
+                f"({len(perturbed.table)} against {len(control.table)}); a "
+                "perturbation must preserve the number of steps"
             )
+        added = float(perturbed.volume(perturbed.forcing[driver]).sum() - control_driver)
+        if abs(added) < 1e-9:
+            raise ValueError(
+                f"variant '{name}' does not change {driver} ({added:.4g} mm); the "
+                "generator has to make the variants actually differ"
+            )
+        word = sign_word(added)
 
-    hog, hog_share = max(shares.items(), key=lambda kv: abs(kv[1]))
-    if abs(hog_share) > max_share:
-        failures.append(
-            f"{hog} absorbs {abs(hog_share):.3f} of the added {driver} "
-            f"(limit {max_share:g})"
-        )
+        shares = {
+            var: float(perturbed.volume(perturbed.table[var]).sum() - control_terms[var]) / added
+            for var in terms
+        }
+        if states:
+            shares["storage"] = (storage_change(perturbed) - control_storage) / added
 
-    accounted = float(sum(shares.values()))
-    if abs(accounted - 1.0) > sum_tolerance:
-        failures.append(
-            f"the responses account for {accounted:.3f} of the added {driver}, "
-            f"not 1.000 (tolerance {sum_tolerance:g})"
-        )
-
-    ok = not failures
-    detail = ", ".join(f"{k} {v:+.3f}" for k, v in shares.items())
-    return CriterionResult(
-        name="counterfactual_response",
-        status=PASS if ok else FAIL,
-        value=accounted,
-        threshold=1.0 + sum_tolerance,
-        message=(
-            f"added {driver} is partitioned ({detail})" if ok else "; ".join(failures)
-        ),
-        diagnostics={
+        prefix = f"{name}: " if several else ""
+        for var, share in shares.items():
+            if var != "storage" and abs(share) < min_share:
+                failures.append(
+                    f"{prefix}{var} barely responds ({share:+.3f} of the {word} {driver}, "
+                    f"minimum {min_share:g})"
+                )
+        hog, hog_share = max(shares.items(), key=lambda kv: abs(kv[1]))
+        if abs(hog_share) > max_share:
+            failures.append(
+                f"{prefix}{hog} absorbs {abs(hog_share):.3f} of the {word} {driver} "
+                f"(limit {max_share:g})"
+            )
+        accounted = float(sum(shares.values()))
+        if abs(accounted - 1.0) > sum_tolerance:
+            failures.append(
+                f"{prefix}the responses account for {accounted:.3f} of the {word} {driver}, "
+                f"not 1.000 (tolerance {sum_tolerance:g})"
+            )
+        per_variant[name] = {
             "added_mm": added,
-            "shares": {k: float(v) for k, v in shares.items()},
+            "shares": shares,
             "largest_share": hog,
             "accounted": accounted,
-        },
+        }
+
+    worst = max(per_variant.values(), key=lambda v: abs(v["accounted"] - 1.0))
+
+    def describe(v):
+        return ", ".join(f"{k} {s:+.3f}" for k, s in v["shares"].items())
+
+    if several:
+        headline = f"changes in {driver} are partitioned"
+        detail = "; ".join(
+            f"{name} ({v['added_mm']:+.0f} mm): {describe(v)}" for name, v in per_variant.items()
+        )
+    else:
+        headline = f"{sign_word(worst['added_mm'])} {driver} is partitioned"
+        detail = describe(worst)
+    diagnostics = {**worst, "variants": per_variant} if several else worst
+    return CriterionResult(
+        name="counterfactual_response",
+        status=FAIL if failures else PASS,
+        value=worst["accounted"],
+        threshold=1.0 + sum_tolerance,
+        message=f"{headline} ({detail})" if not failures else "; ".join(failures),
+        diagnostics=diagnostics,
     )
 
 

--- a/src/hydroturing/criteria/response.py
+++ b/src/hydroturing/criteria/response.py
@@ -63,7 +63,9 @@ def counterfactual_response(
     fails the criterion; the value reported is the pair whose accounted sum
     sits farthest from one. A variant that removes water divides by a
     negative change in the driver, so the shares keep their meaning: the
-    fraction of the removed water each term gave up.
+    fraction of the removed water each term gave up. The minimum is signed,
+    so a term that moves against the change fails it; the largest share is
+    compared in magnitude.
     """
     driver = str(params.get("driver", "pr"))
     terms = list(params.get("terms", ["evspsbl", "mrro"]))
@@ -73,6 +75,8 @@ def counterfactual_response(
     names = params.get("perturbed", "perturbed")
     if isinstance(names, str):
         names = [names]
+    if not names:
+        raise ValueError("counterfactual_response needs at least one variant under 'perturbed'")
     several = len(names) > 1
 
     control = make_window(pick(runs, params, "control", "control"), probe)
@@ -121,9 +125,10 @@ def counterfactual_response(
 
         prefix = f"{name}: " if several else ""
         for var, share in shares.items():
-            if var != "storage" and abs(share) < min_share:
+            if var != "storage" and share < min_share:
+                verdict = "moves the wrong way" if share < 0 else "barely responds"
                 failures.append(
-                    f"{prefix}{var} barely responds ({share:+.3f} of the {word} {driver}, "
+                    f"{prefix}{var} {verdict} ({share:+.3f} of the {word} {driver}, "
                     f"minimum {min_share:g})"
                 )
         hog, hog_share = max(shares.items(), key=lambda kv: abs(kv[1]))

--- a/tests/test_counterfactual_response.py
+++ b/tests/test_counterfactual_response.py
@@ -1,0 +1,96 @@
+"""counterfactual_response on one perturbed variant or several.
+
+The probe mass/precipitation-counterfactual pairs three perturbed variants
+with one control. These tests pin the single-name behaviour, score every
+variant when a list is given, isolate a failure to the variant that caused
+it, and refuse a variant that changes nothing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from hydroturing import registry
+from hydroturing.criteria import get
+from hydroturing.harness import build_case
+from hydroturing.protocol import RunResult
+from hydroturing.runner import get_runner
+from hydroturing.seeds import gate_seeds
+
+
+@pytest.fixture(scope="module")
+def probe():
+    return registry.find_probe("mass/precipitation-counterfactual")
+
+
+@pytest.fixture(scope="module")
+def runs(probe, tmp_path_factory):
+    model = registry.find_model("reference_bucket")
+    seed = gate_seeds(probe.id, 1)[0]
+    root = tmp_path_factory.mktemp("cf")
+    return {
+        variant: get_runner(model).run(model, probe, build_case(probe, seed, variant), root / variant)
+        for variant in probe.variants
+    }
+
+
+@pytest.fixture(scope="module")
+def params(probe):
+    return next(c.params for c in probe.criteria if c.name == "counterfactual_response")
+
+
+def score(runs, probe, params, **override):
+    return get("counterfactual_response")(runs, probe, {**params, **override})
+
+
+def test_a_single_name_keeps_the_original_shape(runs, probe, params):
+    result = score(runs, probe, params, perturbed="wetter20")
+    assert result.passed
+    spinup = runs["control"].case.spinup_steps
+    scored_rain = runs["control"].case.forcing["pr"].iloc[spinup:].sum()
+    assert result.diagnostics["added_mm"] == pytest.approx(0.2 * scored_rain, rel=1e-6)
+    assert set(result.diagnostics) == {"added_mm", "shares", "largest_share", "accounted"}
+    assert result.value == pytest.approx(sum(result.diagnostics["shares"].values()))
+    assert "wetter20" not in result.message
+
+
+def test_a_list_scores_every_variant(runs, probe, params):
+    result = score(runs, probe, params)
+    assert result.passed
+    variants = result.diagnostics["variants"]
+    assert set(variants) == {"wetter20", "wetter10", "drier20"}
+    assert variants["drier20"]["added_mm"] < 0 < variants["wetter10"]["added_mm"] < variants["wetter20"]["added_mm"]
+    for name, v in variants.items():
+        assert 0.5 < v["shares"]["mrro"] < 0.95, name
+        assert 0.03 < v["shares"]["evspsbl"] < 0.5, name
+        assert v["accounted"] == pytest.approx(1.0, abs=1e-6), name
+    assert "drier20" in result.message
+
+
+def test_an_unresponsive_variant_fails_alone(runs, probe, params):
+    unresponsive = dict(runs)
+    d = runs["drier20"]
+    unresponsive["drier20"] = RunResult(d.case, runs["control"].table, d.meta, 0.0)
+    result = score(unresponsive, probe, params)
+    assert not result.passed
+    assert "drier20" in result.message
+    assert "wetter20" not in result.message and "wetter10" not in result.message
+
+
+def test_a_variant_that_changes_nothing_raises(runs, probe, params):
+    same = dict(runs)
+    c = runs["control"]
+    same["same"] = RunResult(c.case, c.table, c.meta, 0.0)
+    with pytest.raises(ValueError, match="does not change pr"):
+        score(same, probe, params, perturbed=["wetter20", "same"])
+
+
+def test_a_window_of_another_length_raises(runs, probe, params):
+    d = runs["drier20"]
+    short_case = replace(d.case, forcing=d.case.forcing.iloc[:-10].reset_index(drop=True))
+    short = dict(runs)
+    short["drier20"] = RunResult(short_case, d.table.iloc[:-10].reset_index(drop=True), d.meta, 0.0)
+    with pytest.raises(ValueError, match="different length"):
+        score(short, probe, params)

--- a/tests/test_counterfactual_response.py
+++ b/tests/test_counterfactual_response.py
@@ -3,7 +3,8 @@
 The probe mass/precipitation-counterfactual pairs three perturbed variants
 with one control. These tests pin the single-name behaviour, score every
 variant when a list is given, isolate a failure to the variant that caused
-it, and refuse a variant that changes nothing.
+it, fail a term that moves against the change, and refuse an empty list or
+a variant that changes nothing.
 """
 
 from __future__ import annotations
@@ -77,6 +78,33 @@ def test_an_unresponsive_variant_fails_alone(runs, probe, params):
     assert not result.passed
     assert "drier20" in result.message
     assert "wetter20" not in result.message and "wetter10" not in result.message
+
+
+@pytest.mark.parametrize("name, factor", [("wetter20", 0.95), ("drier20", 1.05)])
+def test_a_term_moving_against_the_change_fails(runs, probe, params, name, factor):
+    # Evaporation ends 5% below the control's when rain is added, or 5% above
+    # it when rain is removed. The water it trades sits in storage, so only
+    # the signed minimum has anything to object to, alone or in the list.
+    w, c = runs[name], runs["control"]
+    spinup = w.case.spinup_steps
+    table = w.table.copy()
+    moved = (table["evspsbl"] - factor * c.table["evspsbl"]).iloc[spinup:]
+    table.loc[spinup:, "evspsbl"] -= moved
+    table.loc[table.index[-1], "mrso"] += moved.sum()
+    against = dict(runs)
+    against[name] = RunResult(w.case, table, w.meta, 0.0)
+    alone = score(against, probe, params, perturbed=name)
+    assert not alone.passed
+    assert alone.diagnostics["shares"]["evspsbl"] < 0
+    assert alone.message.startswith("evspsbl moves the wrong way") and ";" not in alone.message
+    listed = score(against, probe, params)
+    assert listed.message.startswith(f"{name}: evspsbl moves the wrong way")
+    assert ";" not in listed.message
+
+
+def test_an_empty_list_of_variants_raises(runs, probe, params):
+    with pytest.raises(ValueError, match="at least one variant"):
+        score(runs, probe, params, perturbed=[])
 
 
 def test_a_variant_that_changes_nothing_raises(runs, probe, params):

--- a/tests/test_precipitation_counterfactual.py
+++ b/tests/test_precipitation_counterfactual.py
@@ -8,7 +8,12 @@ import numpy as np
 import pytest
 
 from hydroturing import registry
-from hydroturing.harness import build_case, load_generator, resolve_window_days, run_probe
+from hydroturing.harness import (
+    build_case,
+    load_generator,
+    resolve_window_days,
+    run_probe,
+)
 from hydroturing.scoring import FAIL, PASS
 from hydroturing.seeds import gate_seeds
 

--- a/tests/test_precipitation_counterfactual.py
+++ b/tests/test_precipitation_counterfactual.py
@@ -1,0 +1,61 @@
+"""mass/precipitation-counterfactual: four rainfalls, one weather."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from hydroturing import registry
+from hydroturing.harness import build_case, load_generator, resolve_window_days, run_probe
+from hydroturing.scoring import FAIL, PASS
+from hydroturing.seeds import gate_seeds
+
+VALIDATION_SEED = 20260911
+
+
+@pytest.fixture(scope="module")
+def probe():
+    return registry.find_probe("mass/precipitation-counterfactual")
+
+
+@pytest.mark.parametrize("variant, factor", [("wetter20", 1.20), ("wetter10", 1.10), ("drier20", 0.80)])
+def test_only_the_scored_rain_changes(probe, variant, factor):
+    control = build_case(probe, 7, "control")
+    other = build_case(probe, 7, variant)
+    assert control.n_steps == other.n_steps == 4015
+    assert control.static == other.static
+    for column in ("time", "tas", "pet"):
+        assert control.forcing[column].equals(other.forcing[column]), column
+    spinup = control.spinup_steps
+    assert control.forcing["pr"][:spinup].equals(other.forcing["pr"][:spinup])
+    # Each value is rounded to 1e-6 mm after scaling, so compare depths, not ratios.
+    np.testing.assert_allclose(
+        other.forcing["pr"][spinup:], factor * control.forcing["pr"][spinup:], atol=2e-6
+    )
+
+
+def test_generation_is_deterministic_and_variants_are_checked(probe):
+    generator = load_generator(probe)
+    first = generator.generate(7, "wetter20")[0]
+    assert first.to_csv(index=False) == generator.generate(7, "wetter20")[0].to_csv(index=False)
+    assert not first["pr"].equals(generator.generate(8, "wetter20")[0]["pr"])
+    with pytest.raises(ValueError, match="unknown variant"):
+        generator.generate(7, "wetter")
+
+
+def test_submitted_models_are_scored_on_the_whole_record(probe):
+    submitted = replace(registry.find_model("reference_bucket"), name="submitted_model")
+    assert resolve_window_days(submitted, probe) == 3650
+    assert resolve_window_days(replace(submitted, window_days=30), probe) == 3650
+
+
+def test_baselines_hold_on_a_seed_outside_the_gate(probe):
+    assert VALIDATION_SEED not in gate_seeds(probe.id, probe.n_seeds)
+    for name in probe.must_pass:
+        outcome = run_probe(registry.find_model(name), probe, [VALIDATION_SEED])
+        assert outcome.verdict == PASS, (name, outcome.error or outcome.failing)
+    for name, criterion in probe.must_fail.items():
+        outcome = run_probe(registry.find_model(name), probe, [VALIDATION_SEED])
+        assert outcome.verdict == FAIL and criterion in outcome.failing, (name, outcome.failing)


### PR DESCRIPTION
Closes #18

## What this probe asserts

One seed, four rainfalls after an identical spinup: the control, and every scored wet day 20% wetter, 10% wetter and 20% drier. For each perturbed variant, the change in evaporation, runoff and storage is divided by the change in precipitation. Evaporation and runoff must each take at least 0.03 of it, no term more than 0.95, and the three shares must sum to one within 0.10. Runoff must also rise monotonically along the ladder from drier to wetter.

A model that solves one budget term as the residual closes on every seed but cannot say where added water went. `reference_cheater` is that model: it closes exactly, yet fails here because its evaporation does not respond to the added rain.

Scoring uses the full ten-year record rather than the default 30-day flood window. On that window the exact physical models fail, because runoff inside it carries water stored before it opened.

## Discrimination

| Reference model | Expected | Criterion that catches it |
| --- | --- | --- |
| `reference_bucket`, `flex_lumped`, `flex_topo`, `sacsma_snow17` | PASS | n/a |
| `reference_leaky` | FAIL | `counterfactual_response`: shares sum to 0.850 |
| `reference_cheater` | FAIL | `counterfactual_response`: evaporation share 0.000 |
| `reference_degenerate` | FAIL | `counterfactual_response`: runoff share 0.000 |

The narrowest margin is `sacsma_snow17` runoff at 0.839 against 0.95. `reference_in_sample` is not caught and is stated as a limit in the README.

## Validation

`ht validate`, `ht gate --probe mass/precipitation-counterfactual` and `pytest -q` (328 passed) all pass. `models/result.csv` has one row per evaluated model; `dhbv2` ran in its container and fails `state_bounds`.

## Two changes proposed in #18

Neither was answered in the issue, so both are applied here and each can be reverted on its own.

1. `max_share` is 0.95 rather than the template's 0.90: in a wetter catchment the runoff share of added rain approaches one, and no verdict here changes.
2. `counterfactual_response` accepts a list under `perturbed`, as `response_sign` does, so all three pairs are scored. With a single name the output is byte-identical to before (`tests/test_counterfactual_response.py`).

## Checklist

- [x] There is an `accepted` proposal issue and this PR closes it
- [x] `authors` in `probe.yaml` names every author with `name`, `affiliation` and `orcid`
- [x] `ht validate` passes
- [x] `ht gate --probe mass/precipitation-counterfactual` passes
- [x] The generator is deterministic given a seed and commits no data
- [x] The probe runs in under a minute on a two-core runner
- [x] Tolerance and denominator are justified in `probe.yaml`
- [x] I constructed a model that passes closure without doing physics, and a criterion catches it
