### PR TITLE
[PROBE: mass] human-abstraction - a prescribed withdrawal must leave the budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Paths inside `request.json` are relative to the request file's directory.
 
 ```
 /io/request.json          read-only: opaque case id, model seed, timestep, n_steps, outputs
-/io/input/forcing.csv     read-only: columns time, pr, tas, pet (mm/day, degC, mm/day)
+/io/input/forcing.csv     read-only: columns time, pr, tas, pet (mm/day, degC, mm/day),
+                          and, when a probe prescribes a human withdrawal, abstr (mm/day, net)
 /io/input/static.json     read-only: catchment attributes
 /io/output/result.csv     write: one row per forcing row, spinup included
 /io/output/run.json       write: {"status": "ok"}
@@ -43,6 +44,14 @@ The model seed is deterministic for reproducible stochastic inference, but it
 is not the generator seed recorded in the host-side report. Exit 0 on success.
 There is no network. Do not attempt to download weights or data at run time;
 bake them into the image.
+
+Some probes prescribe a human withdrawal in the forcing as an `abstr` column
+(mm/day, net of return flow). Honouring it means removing that water from the
+stores and fluxes the model reports, and declaring whatever was actually
+removed as a negative `gwex`. A model that never reads the column reports a
+budget that closes on its own yet misses the withdrawal; the probe scores that
+as a failure, not as INCOMPLETE, because such a model reports everything the
+criterion needs.
 
 ## The evaluation window
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,6 +29,10 @@ authors:
       Department of Civil and Environmental Engineering (D.I.C.A.),
       Politecnico di Milano, Milano 20133, Italy
     orcid: "https://orcid.org/0009-0001-9836-4261"
+  - given-names: Yuanhang
+    family-names: Liu
+    affiliation: Independent Researcher
+    orcid: "https://orcid.org/0009-0005-9633-6004"
 repository-code: "https://github.com/Flood-Lab/HydroTuring"
 url: "https://flood-lab.github.io/HydroTuring/"
 license: MIT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@ long.
 | `mass/phase-counterfactual` | Zhi Li (CU Boulder) |
 | `mass/time-origin-invariance` | Siavash Shams (Columbia University) |
 | `mass/precipitation-counterfactual` | Qingyi Yang (Politecnico di Milano) |
+| `mass/human-abstraction` | Yuanhang Liu (Independent Researcher) |
 | `energy/pet-consistency` | Zhi Li (CU Boulder) |
 | `energy/latent-heat-et-consistency` | Changming Li (SCUT) |
 | `energy/evaporative-partition` | Changming Li (SCUT) |

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ not.
 
 ## The probes
 
-Nineteen: fourteen under mass, four under energy and one under momentum. Each was
+Twenty: fifteen under mass, four under energy and one under momentum. Each was
 merged only after the acceptance gate saw it pass four physical models, a
 bucket that conserves water exactly, two hand-written FLEX models and the
 NWS's SAC-SMA with Snow-17, and fail a purpose-built broken one on the
 named criterion. A probe that fails a
 physical model is examined before the model is; that is the first thing done
-with any probe pull request. Eleven of the nineteen can be scored on a model
+with any probe pull request. Eleven of the twenty can be scored on a model
 that reports runoff and nothing else. `ht list` prints them;
-[ROADMAP.md](ROADMAP.md#probes-we-want) has the thirteen more we want, all
+[ROADMAP.md](ROADMAP.md#probes-we-want) has the twelve more we want, all
 unclaimed.
 
 | Probe | Law | What it asks | The broken model it catches |
@@ -95,6 +95,7 @@ unclaimed.
 | [`mass/phase-counterfactual`](probes/mass/phase-counterfactual) | mass | The same water falling as rain instead of snow: timing moves, the integrated volumes may not. | `reference_sublimating` |
 | [`mass/time-origin-invariance`](probes/mass/time-origin-invariance) | mass | The same weather under a 28-year calendar shift that preserves seasons and leap days: evaporation, runoff and water stores must agree. | `reference_calendar`, `reference_degenerate`, `reference_leaky` |
 | [`mass/precipitation-counterfactual`](probes/mass/precipitation-counterfactual) | mass | The same seed 20% wetter, 10% wetter and 20% drier: the water added or removed must be partitioned among evaporation, runoff and storage, and runoff must rise from drier to wetter. | `reference_cheater`, `reference_leaky`, `reference_degenerate` |
+| [`mass/human-abstraction`](probes/mass/human-abstraction) | mass | A prescribed net irrigation withdrawal must leave the budget: the same weather run with and without it, and the difference must account for exactly the abstracted volume. | `reference_abstraction_blind`, `reference_leaky` |
 | [`energy/pet-consistency`](probes/energy/pet-consistency) | energy | Evaporation reaches demand when the model's own soil is wettest, stays below it, and falls when the soil is driest. | `reference_thirsty` |
 | [`energy/latent-heat-et-consistency`](probes/energy/latent-heat-et-consistency) | energy | The evaporation a model reports as water and the evaporation implied by the latent heat it reports: are they the same evaporation? | `reference_two_head`, `reference_constant_lambda`, `reference_sublimation_blind`, `reference_energy_leak` |
 | [`energy/evaporative-partition`](probes/energy/evaporative-partition) | energy | One summer without rain under net radiation that did not change: the latent heat a drying surface gives up has to warm the air. | `reference_two_head`, `reference_ground_dodge` |
@@ -122,14 +123,15 @@ goes untested.
 
 | Model | Kind | What it does | Standing |
 | --- | --- | --- | --- |
-| [`google_flood_forecast`](models/google_flood_forecast) | submitted | The mean-embedding forecast LSTM behind Google Flood Hub, at the published weights. Predicts discharge and nothing else. | **FAIL (INCOMPLETE)**, 5 of 19 probes passed. Runoff-only, so eight probes cannot ask it anything; of the eleven that ask on runoff alone it passes the runoff bounds, memory, area, causality and steady state, and fails step, extreme rain, phase, warming, dry-down, and a 0.18 mm/day dip after an added storm |
-| [`dhbv2`](models/dhbv2) | submitted | δHBV 2.0, the MHPI group's differentiable HBV: neural networks write the parameters of a bucket model that reports its stores and its evaporation. | **FAIL (VIOLATION)**, 11 of 19 probes passed. Its learned regional-groundwater term, declared as `gwex`, closes the budget to 1e-8; what remains is a learned field capacity twice the catchment's, a response to doubled rain above the rain added, a runoff depth that changes with the area it is told, and a third more runoff when snow falls as rain |
-| [`wflow_sbm`](models/wflow_sbm) | submitted | Deltares' Wflow.jl SBM: a soil column with unsaturated and saturated stores, interception, snow and kinematic-wave routing, adapted in Julia and run on one representative cell at the resolution of Wflow's Moselle model. | **FAIL (INCOMPLETE)**, 14 of 19 probes passed. It reports no heat fluxes, so the three energy-flux probes cannot ask it anything; its water budget closes to 2e-4 of the rain and it passes the area, routing, step, calendar, causality, extreme-rain, phase, precipitation-counterfactual and warming probes. Both come from its soil column: a storm that does not fill the column makes almost no runoff, and under the shipped mapping a wet month's extra water has already been evaporated down to the rooting depth when the storm arrives, so the wetter catchment runs off no more than the dry one; and once the root zone dries in a rainless spell, drainage from the unsaturated store raises a water table that sits below the roots, and lateral flow rises with no rain. Both move with how the stated soil capacity is mapped onto soil thickness and roots |
+| [`google_flood_forecast`](models/google_flood_forecast) | submitted | The mean-embedding forecast LSTM behind Google Flood Hub, at the published weights. Predicts discharge and nothing else. | **FAIL (INCOMPLETE)**, 5 of 20 probes passed. Runoff-only, so nine probes cannot ask it anything; of the eleven that ask on runoff alone it passes the runoff bounds, memory, area, causality and steady state, and fails step, extreme rain, phase, warming, dry-down, and a 0.18 mm/day dip after an added storm |
+| [`dhbv2`](models/dhbv2) | submitted | δHBV 2.0, the MHPI group's differentiable HBV: neural networks write the parameters of a bucket model that reports its stores and its evaporation. | **FAIL (VIOLATION)**, 11 of 20 probes passed. Its learned regional-groundwater term, declared as `gwex`, closes the budget to 1e-8; what remains is a learned field capacity twice the catchment's, a response to doubled rain above the rain added, a runoff depth that changes with the area it is told, a third more runoff when snow falls as rain, and on `mass/human-abstraction` it never reads the prescribed withdrawal, so it accounts for none of the 380 mm and trips that probe's `state_bounds` on the same learned field capacity |
+| [`wflow_sbm`](models/wflow_sbm) | submitted | Deltares' Wflow.jl SBM: a soil column with unsaturated and saturated stores, interception, snow and kinematic-wave routing, adapted in Julia and run on one representative cell at the resolution of Wflow's Moselle model. | **FAIL (INCOMPLETE)**, 14 of 20 probes passed. It reports no heat fluxes, so the three energy-flux probes cannot ask it anything; its water budget closes to 2e-4 of the rain and it passes the area, routing, step, calendar, causality, extreme-rain, phase, precipitation-counterfactual and warming probes. Both come from its soil column: a storm that does not fill the column makes almost no runoff, and under the shipped mapping a wet month's extra water has already been evaporated down to the rooting depth when the storm arrives, so the wetter catchment runs off no more than the dry one; and once the root zone dries in a rainless spell, drainage from the unsaturated store raises a water table that sits below the roots, and lateral flow rises with no rain. Both move with how the stated soil capacity is mapped onto soil thickness and roots |
 | `reference_bucket` | exact | conserves water exactly by construction | must pass every probe that can ask it anything; INCOMPLETE on the three energy-flux probes, which need fluxes it does not report |
-| [`flex_lumped`](models/flex_lumped) | physical | lumped FLEX/HBV: interception, beta-partitioned unsaturated store, fast and slow reservoirs, triangular lag | must pass every probe that can ask it anything; **PASS**, 16 of 19, INCOMPLETE on the three energy-flux probes |
-| [`flex_topo`](models/flex_topo) | physical | FLEX-Topo: plateau, hillslope and wetland units on real Wark fractions sharing one groundwater store | must pass every probe that can ask it anything; **PASS**, 16 of 19, INCOMPLETE on the three energy-flux probes |
-| [`sacsma_snow17`](models/sacsma_snow17) | physical | the NWS's SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it | must pass every probe that can ask it anything; **PASS**, 16 of 19, INCOMPLETE on the three energy-flux probes |
+| [`flex_lumped`](models/flex_lumped) | physical | lumped FLEX/HBV: interception, beta-partitioned unsaturated store, fast and slow reservoirs, triangular lag | must pass every probe that can ask it anything; **PASS**, 17 of 20, INCOMPLETE on the three energy-flux probes |
+| [`flex_topo`](models/flex_topo) | physical | FLEX-Topo: plateau, hillslope and wetland units on real Wark fractions sharing one groundwater store | must pass every probe that can ask it anything; **PASS**, 17 of 20, INCOMPLETE on the three energy-flux probes |
+| [`sacsma_snow17`](models/sacsma_snow17) | physical | the NWS's SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it | must pass every probe that can ask it anything; **PASS**, 17 of 20, INCOMPLETE on the three energy-flux probes |
 | `reference_coupled` | exact | the bucket with snow sublimation and a surface energy budget: every kilogram converted at the latent heat of the phase it actually underwent | must pass every criterion of the three energy-flux probes; supports daily and hourly steps |
+| `reference_abstraction_blind` | broken | the same bucket, blind to the prescribed withdrawal, so the two variants come out identical | caught by `human_abstraction` |
 | `reference_two_head` | broken | a water head and an energy head that never meet: both budgets close to 1e-15 and the latent heat implies an evaporation it never reported | caught by `flux_identity` |
 | `reference_constant_lambda` | broken | coherent, but converts every kilogram at the same latent heat of vaporisation | caught by `flux_identity` |
 | `reference_sublimation_blind` | broken | coherent for liquid water, but converts snow sublimation at the latent heat of vaporisation instead of sublimation | caught by `flux_identity` |
@@ -309,7 +311,7 @@ where that conversation happens, before and alongside the issues.
 
 ## Status
 
-Suite `0.1.0`, pre-release. Nineteen probes, fourteen mass, four energy, one momentum, synthetic track only. More
+Suite `0.1.0`, pre-release. Twenty probes, fifteen mass, four energy, one momentum, synthetic track only. More
 energy and momentum probes, and the real-data track, are next. The harness runs paired cases and
 scores labelled regimes, so the generalisation probes on the roadmap —
 extrapolation in space and time, counterfactual response, invariance — are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,9 +115,12 @@ A branching network. Mass must close reach by reach, not only basin-wide.
 *Discriminates:* models that conserve globally while moving water between
 reaches non-physically.
 
-### `mass/human-abstraction` &middot; standard &middot; **unclaimed**
-Irrigation withdrawal and return flow, which must both appear in the budget.
+### `mass/human-abstraction` &middot; **merged**
+A prescribed net irrigation withdrawal must leave the budget: the same weather
+run with and without it, and the difference between the two runs must account
+for exactly the abstracted volume (net of return flow).
 *Discriminates:* models that treat abstraction as an unaccounted sink.
+Contributed by Yuanhang Liu.
 
 ---
 

--- a/models/flex_lumped/README.md
+++ b/models/flex_lumped/README.md
@@ -29,3 +29,8 @@ is treated as rain, which conserves water and is wrong about timing.
 On the closure probe's first gate seed the budget closes to 4e-16 of the
 precipitation; runoff ratio 0.40, ET 0.66 of potential; runoff volume at
 the hourly step within 2.4 % of the daily one.
+
+With a prescribed human withdrawal in the forcing (`abstr`), the adapter
+takes it from the unsaturated store first and from the day's runoff second,
+and declares what it removed as a negative `gwex`; absent the column it is
+unchanged.

--- a/models/flex_lumped/ht_adapter.py
+++ b/models/flex_lumped/ht_adapter.py
@@ -37,7 +37,7 @@ import json
 import sys
 from pathlib import Path
 
-COLUMNS = ["time", "pr", "evspsbl", "mrro", "mrso", "snw", "canopy", "gw", "channel"]
+COLUMNS = ["time", "pr", "evspsbl", "mrro", "gwex", "mrso", "snw", "canopy", "gw", "channel"]
 MODEL = {"name": "flex_lumped", "version": "1.0.0"}
 
 TIMESTEP_DAYS = {"PT1D": 1.0, "PT1H": 1.0 / 24.0, "PT15M": 1.0 / 96.0, "PT5M": 1.0 / 288.0, "PT1M": 1.0 / 1440.0}
@@ -101,6 +101,14 @@ def simulate(forcing: list[dict], static: dict, dt: float) -> list[dict]:
         P = pr_rate * dt
         Ep = pet_rate * dt
 
+        # The human term, first call on the store: a prescribed withdrawal
+        # (`abstr`, mm/day net of return flow) is taken from the unsaturated
+        # store, and whatever the store cannot supply later from the day's
+        # generated runoff. Absent the column nothing changes.
+        want = max(step.get("abstr", 0.0), 0.0) * dt
+        removed = min(su, want)
+        su -= removed
+
         # Interception store; evaporation from it only on rainless steps.
         if P > 0.0:
             si += P
@@ -138,6 +146,16 @@ def simulate(forcing: list[dict], static: dict, dt: float) -> list[dict]:
         qs = min(ks * ss, ss)
         ss -= qs
 
+        # The human term, second call: the day's generated runoff.
+        rest = want - removed
+        take = min(qf, rest)
+        qf -= take
+        removed += take
+        rest -= take
+        take = min(qs, rest)
+        qs -= take
+        removed += take
+
         generated.append(qf + qs)
         n = len(generated)
         routed = sum(weights[k] * generated[n - 1 - k] for k in range(min(len(weights), n)))
@@ -147,6 +165,7 @@ def simulate(forcing: list[dict], static: dict, dt: float) -> list[dict]:
             "pr": pr_rate,
             "evspsbl": (ei + ea) / dt,
             "mrro": routed / dt,
+            "gwex": -removed / dt,
             "mrso": su,
             "snw": 0.0,
             "canopy": si,
@@ -167,7 +186,7 @@ def read_forcing(path: Path) -> list[dict]:
     with open(path, newline="") as fh:
         rows = list(csv.DictReader(fh))
     for row in rows:
-        for key in ("pr", "tas", "pet"):
+        for key in ("pr", "tas", "pet", "abstr"):
             if key in row:
                 row[key] = float(row[key])
     return rows

--- a/models/flex_lumped/model.yaml
+++ b/models/flex_lumped/model.yaml
@@ -17,7 +17,7 @@ runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
 timestep: [PT1D, PT1H, PT15M, PT5M, PT1M]
 emits:
-  fluxes: [pr, evspsbl, mrro]
+  fluxes: [pr, evspsbl, mrro, gwex]
   states: [mrso, snw, canopy, gw, channel]
 needs_forcing: [pr, tas, pet]
 supports:

--- a/models/flex_topo/README.md
+++ b/models/flex_topo/README.md
@@ -39,3 +39,8 @@ scaled to the catchment's soil capacity keeping their ratios and every
 Reports area-weighted `canopy`, `mrso`, `gw` (the shared slow reservoir)
 and `channel` (fast reservoirs plus water in the lag). No snow module:
 `snw` is identically zero.
+
+With a prescribed human withdrawal in the forcing (`abstr`), the adapter takes
+it from the three units' unsaturated stores in proportion to their
+area-weighted water and then from the day's runoff, and declares what it
+removed as a negative `gwex`; absent the column it is unchanged.

--- a/models/flex_topo/ht_adapter.py
+++ b/models/flex_topo/ht_adapter.py
@@ -58,7 +58,7 @@ import json
 import sys
 from pathlib import Path
 
-COLUMNS = ["time", "pr", "evspsbl", "mrro", "mrso", "snw", "canopy", "gw", "channel"]
+COLUMNS = ["time", "pr", "evspsbl", "mrro", "gwex", "mrso", "snw", "canopy", "gw", "channel"]
 MODEL = {"name": "flex_topo", "version": "1.0.0"}
 TIMESTEP_DAYS = {"PT1D": 1.0, "PT1H": 1.0 / 24.0, "PT15M": 1.0 / 96.0, "PT5M": 1.0 / 288.0, "PT1M": 1.0 / 1440.0}
 
@@ -138,6 +138,19 @@ def simulate(forcing: list[dict], static: dict, dt: float) -> list[dict]:
         P = pr_rate * dt
         Ep = pet_rate * dt
 
+        # The human term, first call on the stores: a prescribed withdrawal
+        # (`abstr`, mm/day net of return flow) is taken across the three
+        # units' unsaturated stores in proportion to their area-weighted
+        # water, so the reported (area-weighted) soil depth falls by exactly
+        # what was removed. Absent the column nothing changes.
+        want = max(step.get("abstr", 0.0), 0.0) * dt
+        total_su = sum(frac[n_] * su[n_] for n_ in units)
+        take_su = min(total_su, want)
+        if total_su > 0.0:
+            for n_ in units:
+                su[n_] -= (su[n_] / total_su) * take_su
+        removed = take_su
+
         evap = 0.0
         fast_out = 0.0
         to_slow = 0.0
@@ -200,6 +213,16 @@ def simulate(forcing: list[dict], static: dict, dt: float) -> list[dict]:
         qs = min(catchment["Ks"] * ss, ss)
         ss -= qs
 
+        # The human term, second call: the day's generated runoff.
+        rest = want - removed
+        take = min(fast_out, rest)
+        fast_out -= take
+        removed += take
+        rest -= take
+        take = min(qs, rest)
+        qs -= take
+        removed += take
+
         generated.append(qs + fast_out)
         n = len(generated)
         routed = sum(weights[k] * generated[n - 1 - k] for k in range(min(len(weights), n)))
@@ -208,6 +231,7 @@ def simulate(forcing: list[dict], static: dict, dt: float) -> list[dict]:
             "pr": pr_rate,
             "evspsbl": evap / dt,
             "mrro": routed / dt,
+            "gwex": -removed / dt,
             "mrso": sum(frac[n_] * su[n_] for n_ in units),
             "snw": 0.0,
             "canopy": sum(frac[n_] * si[n_] for n_ in units),
@@ -227,7 +251,7 @@ def read_forcing(path: Path) -> list[dict]:
     with open(path, newline="") as fh:
         rows = list(csv.DictReader(fh))
     for row in rows:
-        for key in ("pr", "tas", "pet"):
+        for key in ("pr", "tas", "pet", "abstr"):
             if key in row:
                 row[key] = float(row[key])
     return rows

--- a/models/flex_topo/model.yaml
+++ b/models/flex_topo/model.yaml
@@ -18,7 +18,7 @@ runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
 timestep: [PT1D, PT1H, PT15M, PT5M, PT1M]
 emits:
-  fluxes: [pr, evspsbl, mrro]
+  fluxes: [pr, evspsbl, mrro, gwex]
   states: [mrso, snw, canopy, gw, channel]
 needs_forcing: [pr, tas, pet]
 supports:

--- a/models/reference_abstraction_blind/ht_adapter.py
+++ b/models/reference_abstraction_blind/ht_adapter.py
@@ -10,9 +10,9 @@ import json
 import sys
 from pathlib import Path
 
-COLUMNS = ["time", "pr", "evspsbl", "mrro", "gwex", "mrso", "snw", "canopy", "channel"]
+COLUMNS = ["time", "pr", "evspsbl", "mrro", "mrso", "snw", "canopy", "channel"]
 
-MODEL = {"name": "reference_bucket", "version": "1.0.0"}
+MODEL = {"name": "reference_abstraction_blind", "version": "1.0.0"}
 
 
 EVAP_SHAPE = 0.5  # soil moisture at which evaporation reaches its potential rate
@@ -41,12 +41,6 @@ def simulate(forcing, static, dt_days=1.0):
     catchment integrates the same water whatever step the weather arrives
     at. At a daily step every factor is exactly 1.0 and the arithmetic is
     bit for bit what it was before the step was a parameter.
-
-    When the forcing carries an `abstr` column (mm/day, net of return flow),
-    the prescribed withdrawal is taken from the soil store first and any
-    remainder from the day's runoff before it leaves, and whatever was
-    actually removed is declared as a negative `gwex`. Absent the column the
-    model is bit for bit the original bucket.
     """
     soil_cap = static["soil_capacity_mm"]
     canopy_cap = static["canopy_capacity_mm"]
@@ -61,14 +55,8 @@ def simulate(forcing, static, dt_days=1.0):
 
     for step in forcing:
         pr_rate, tas, pet_rate = step["pr"], step["tas"], step["pet"]
-        abstr_rate = step.get("abstr", 0.0)
         pr = pr_rate * dt_days
         pet = pet_rate * dt_days
-
-        # The human term, first call on the store.
-        want = max(abstr_rate, 0.0) * dt_days
-        removed = min(soil, want)
-        soil -= removed
 
         snowfall = pr if tas < t_snow else 0.0
         rain = 0.0 if tas < t_snow else pr
@@ -94,22 +82,11 @@ def simulate(forcing, static, dt_days=1.0):
         soil_evap = min(soil, pet_left * min(1.0, soil / (EVAP_SHAPE * soil_cap)))
         soil -= soil_evap
 
-        # The human term, second call: the day's outflow.
-        rest = want - removed
-        divert = min(surface, rest)
-        surface -= divert
-        removed += divert
-        rest -= divert
-        divert = min(baseflow, rest)
-        baseflow -= divert
-        removed += divert
-
         rows.append({
             "time": step["time"],
             "pr": pr_rate,
             "evspsbl": (canopy_evap + soil_evap) / dt_days,
             "mrro": (surface + baseflow) / dt_days,
-            "gwex": -removed / dt_days,
             "mrso": soil,
             "snw": swe,
             "canopy": canopy,
@@ -129,7 +106,7 @@ def read_forcing(path: Path) -> list[dict]:
     with open(path, newline="") as fh:
         rows = list(csv.DictReader(fh))
     for row in rows:
-        for key in ("pr", "tas", "pet", "abstr"):
+        for key in ("pr", "tas", "pet"):
             if key in row:
                 row[key] = float(row[key])
     return rows

--- a/models/reference_abstraction_blind/model.yaml
+++ b/models/reference_abstraction_blind/model.yaml
@@ -1,0 +1,21 @@
+name: reference_abstraction_blind
+version: "1.0.0"
+description: >
+  The exact bucket, blind to a prescribed human abstraction. It conserves
+  water perfectly — over the water it knows about. A forcing column naming a
+  withdrawal is not read, so a run with irrigation and a run without it come
+  out identical, and the abstracted water is missing from nothing it reports.
+  Broken in exactly one way, so the human_abstraction criterion has a named
+  model to catch: an unaccounted sink that no single-run budget can see.
+authors: ["HydroTuring maintainers"]
+license: PolyForm-Noncommercial-1.0.0
+runner: subprocess
+entrypoint: ["python3", "ht_adapter.py"]
+timestep: [PT1D, PT1H, PT15M, PT5M, PT1M]
+emits:
+  fluxes: [pr, evspsbl, mrro]
+  states: [mrso, snw, canopy, channel]
+needs_forcing: [pr, tas, pet]
+supports:
+  perturbation: true
+resources: {cpu: 1, memory_gb: 1, gpu: false}

--- a/models/reference_bucket/model.yaml
+++ b/models/reference_bucket/model.yaml
@@ -11,7 +11,7 @@ runner: subprocess
 entrypoint: ["python3", "ht_adapter.py"]
 timestep: [PT1D, PT1H, PT15M, PT5M, PT1M]
 emits:
-  fluxes: [pr, evspsbl, mrro]
+  fluxes: [pr, evspsbl, mrro, gwex]
   states: [mrso, snw, canopy, channel]
 needs_forcing: [pr, tas, pet]
 supports:

--- a/models/result.csv
+++ b/models/result.csv
@@ -221,3 +221,8 @@ run_date,model,version,suite_version,runner,probe,verdict,reason,window,seeds,de
 2026-09-11,wflow_sbm,1.0.4-ht.2,0.1.0,docker,mass/warming-response,PASS,OK,full record,732983943 1239936057 1746888171 106356638 613308752,all criteria pass
 2026-09-11,wflow_sbm,1.0.4-ht.2,0.1.0,docker,momentum/routing-conservation,PASS,OK,full record,417694852 924646966 1431599080,all criteria pass
 2026-09-11,wflow_sbm,1.0.4-ht.2,0.1.0,docker,mass/precipitation-counterfactual,PASS,OK,full record,872466880 1379418994 1886371108,residual 0.019% of driver
+2026-09-11,flex_lumped,1.0.0,0.1.0,subprocess,mass/human-abstraction,PASS,OK,full record,1129545695 1636497809 2143449923,residual 0.000% of driver
+2026-09-11,flex_topo,1.0.0,0.1.0,subprocess,mass/human-abstraction,PASS,OK,full record,1129545695 1636497809 2143449923,residual 0.000% of driver
+2026-09-11,sacsma_snow17,1.0.0,0.1.0,subprocess,mass/human-abstraction,PASS,OK,full record,1129545695 1636497809 2143449923,residual 0.000% of driver
+2026-09-11,google_flood_forecast,0.1.0-828dfc5,0.1.0,docker,mass/human-abstraction,FAIL,INCOMPLETE,not run,,"does not report pr, evspsbl, mrso, snw, canopy"
+2026-09-11,dhbv2,0.5.4-hbv2ep100.3,0.1.0,docker,mass/human-abstraction,FAIL,VIOLATION,full record,1129545695 1636497809 2143449923,"human_abstraction: of the prescribed 380 mm of abstr, the budget difference accounts for all but +380.0 mm (100.00%, limit 5%): evspsbl +0.0 mm, mrro +0.0 mm, storage +0.0 mm; state_bounds: mrso leaves [0, 320] on 3650 steps (range 526 to 735)"

--- a/models/sacsma_snow17/README.md
+++ b/models/sacsma_snow17/README.md
@@ -40,7 +40,7 @@ density diagnostics, and the user-specified melt-factor curve.
 | Choice | Why |
 | --- | --- |
 | Snow-17 `SCF = 1.0` | the gauge-catch multiplier manufactures snow above one; a physical reference is fed what fell |
-| SAC-SMA `SIDE = 0.02`, declared as `gwex` | deep baseflow leaves the catchment for good; declared as a negative exchange so the budget closes over what the model says it did |
+| SAC-SMA `SIDE = 0.02`, declared as `gwex` | deep baseflow leaves the catchment for good; declared as a negative exchange so the budget closes over what the model says it did. When the forcing carries `abstr`, the prescribed withdrawal is removed from the SAC stores and the day's runoff and added to `gwex` the same way |
 | `RIVA = 0.02` in `evspsbl` | riparian evaporation from channel inflow is evaporation, as the Fortran counts it |
 | `UZTWM + UZFWM + LZTWM` = the catchment's soil capacity | a physical model is told its catchment; the three tension/upper stores are rescaled from the default set keeping their ratios, lower-zone free water keeps its defaults |
 | `PXTEMP`, `MBASE` = the catchment's snow threshold | same reason |
@@ -58,7 +58,8 @@ components: `mrso` = UZTWC + UZFWC + LZTWC (+ ADIMC on its area), `gw` =
 LZFSC + LZFPC, `snw` = Snow-17's total water equivalent (pack plus liquid
 plus lagged excess plus storage), `channel` = channel inflow generated but
 not yet released by the hydrograph, `gwex` = minus the non-channel
-baseflow. Steps: PT1D and PT1H, the whole hours Snow-17 is defined on.
+baseflow, plus any prescribed human withdrawal removed this step. Steps:
+PT1D and PT1H, the whole hours Snow-17 is defined on.
 
 ## Result
 

--- a/models/sacsma_snow17/ht_adapter.py
+++ b/models/sacsma_snow17/ht_adapter.py
@@ -92,6 +92,7 @@ def simulate(forcing: list[dict], static: dict, timestep: str) -> tuple[list[dic
     elev = float(static.get("elevation_m", 500.0))
     pa = surface_pressure_hpa(elev)
     weights = gamma_uh(UH["shape"], UH["scale_days"], dt_days)
+    parea = 1.0 - sac["adimp"] - sac["pctim"]
 
     sac_state = SacState(uztwc=0.5 * sac["uztwm"], uzfwc=0.2 * sac["uzfwm"], lztwc=0.5 * sac["lztwm"],
                          lzfsc=0.2 * sac["lzfsm"], lzfpc=0.5 * sac["lzfpm"], adimc=0.5 * (sac["uztwm"] + sac["lztwm"]))
@@ -108,7 +109,31 @@ def simulate(forcing: list[dict], static: dict, timestep: str) -> tuple[list[dic
         raim, _snowfall = snow17(hours, when.year, when.month, when.day, pcp, tas, lat, snow, pa, ADC, snow_state)
         fluxes = sac1(dt_days, raim, pet, sac, sac_state)
 
-        generated.append(fluxes["tci"])
+        # The human term: the prescribed withdrawal (`abstr`, mm/day net of
+        # return flow) is taken from the SAC stores, upper zone first,
+        # converting a catchment-average depth into each store's own area
+        # weighting (PAREA for the five zone stores, ADIMP for the additional
+        # impervious store), so the reported catchment-average storage falls by
+        # exactly what was removed. Absent the column nothing changes.
+        want = max(step.get("abstr", 0.0), 0.0) * dt_days
+        removed = 0.0
+        for attr, weight in (("uztwc", parea), ("uzfwc", parea), ("lztwc", parea),
+                             ("lzfsc", parea), ("lzfpc", parea), ("adimc", sac["adimp"])):
+            if want - removed <= 1e-12:
+                break
+            local = getattr(sac_state, attr)
+            local_take = min(local, (want - removed) / weight)
+            setattr(sac_state, attr, local - local_take)
+            removed += weight * local_take
+
+        # The human term, second call: the day's generated runoff, the same
+        # store-first-then-runoff rule the other adapters follow.
+        tci = fluxes["tci"]
+        take = min(tci, want - removed)
+        tci -= take
+        removed += take
+
+        generated.append(tci)
         n = len(generated)
         routed = sum(weights[k] * generated[n - 1 - k] for k in range(min(len(weights), n)))
         soil, lower = sac_storage(sac, sac_state)
@@ -117,7 +142,7 @@ def simulate(forcing: list[dict], static: dict, timestep: str) -> tuple[list[dic
             "pr": pr_rate,
             "evspsbl": fluxes["tet"] / dt_days,
             "mrro": routed / dt_days,
-            "gwex": -fluxes["bfncc"] / dt_days,  # deep baseflow leaves the catchment
+            "gwex": -(fluxes["bfncc"] + removed) / dt_days,  # deep baseflow plus the prescribed withdrawal leaves the catchment
             "mrso": soil,
             "snw": snow_state.total(),
             "canopy": 0.0,
@@ -133,7 +158,7 @@ def simulate(forcing: list[dict], static: dict, timestep: str) -> tuple[list[dic
         "port": "sacsma_snow17.py, checked against the f2py build of the Fortran",
         "parameters": {"sac": sac, "snow17": snow, "unit_hydrograph": UH},
         "canopy": "identically zero; SAC-SMA has no interception store",
-        "gwex": "minus the non-channel baseflow (SIDE); deep groundwater leaving the catchment",
+        "gwex": "minus the non-channel baseflow (SIDE), deep groundwater leaving the catchment, plus any prescribed human withdrawal removed this step",
     }
     return rows, notes
 
@@ -142,7 +167,7 @@ def read_forcing(path: Path) -> list[dict]:
     with open(path, newline="") as fh:
         rows = list(csv.DictReader(fh))
     for row in rows:
-        for key in ("pr", "tas", "pet"):
+        for key in ("pr", "tas", "pet", "abstr"):
             if key in row:
                 row[key] = float(row[key])
     return rows

--- a/probes/mass/human-abstraction/README.md
+++ b/probes/mass/human-abstraction/README.md
@@ -1,0 +1,95 @@
+# mass/human-abstraction
+
+**Law:** mass conservation · **Track:** synthetic · **Step:** daily
+
+> The same weather twice — once natural, once with a prescribed net
+> irrigation withdrawal. The abstracted water must leave the reported budget,
+> and the difference between the two runs must account for exactly the
+> prescribed volume.
+
+## The question
+
+Irrigation withdrawal is the oldest unaccounted sink in hydrology: water a
+model was told left the catchment, that it never removed from any store or
+flux it reports. Every single-run criterion in the suite is blind to the
+omission, because nothing leaks — the water was never taken. The only way to
+catch it is the paired question: run the same seed with and without the human
+term and ask where the abstracted water went.
+
+## The case
+
+`generate.py` draws ten years of daily weather once from the recorded seed,
+plus one spinup year. The `natural` variant carries the abstraction column as
+zeros; the `irrigated` variant carries the schedule. Precipitation,
+temperature and PET are byte-identical between the two.
+
+The schedule is a smooth growing-season bump (May–September, sin² shape,
+peak 0.5 mm/day net), giving ~38 mm/yr catchment-mean against ~830 mm/yr of
+rain — a modest irrigated fraction, not an irrigation district. The amplitude
+is bracketed from both sides: a blind model must fail by a wide margin (at
+~380 mm over the record the residual is twenty times the tolerance), and the
+withdrawal must stay honourable (at 2.5 mm/day peak the soil column empties
+every summer and even an exact model under-removes 27-30% of the prescription;
+at 0.5 mm/day the honest model's residual is ~0.0% on the three scored seeds,
+and stays below ~1% on arbitrary seeds — far under the tolerance). The schedule
+is a NET withdrawal (mm/day, gross abstraction minus return flow); that the
+budget term is net rather than gross follows Perry (2007, doi:10.1002/ird.323)
+and Döll & Siebert (2002, doi:10.1029/2001WR000355). No gross-to-net fraction
+is applied: the generator's schedule is already net.
+
+The human term is a visible forcing column `abstr` (mm/day), the prescribed
+NET withdrawal. It is prescribed by the case, not reported by the model: an
+external driver the model must honour, in the same sense that `pr` is. A model
+honours it by removing the water from its stores and fluxes; a model that
+routes the removal outside its reported budget declares it as a (negative)
+`gwex`. Note that `human_abstraction` scores the difference between the runs
+and does not include `gwex`, and nothing on this probe scores the irrigated
+run's own `gwex`; a declared exchange that responds to the drier stores
+therefore lands in the residual. That is harmless here (SAC-SMA's deep loss,
+SIDE, is the whole of its 0.15-0.29%), but a model with a large
+storage-dependent exchange would meet it first.
+
+## The criteria
+
+| criterion | what it asserts |
+|---|---|
+| `closure` | the control run closes its own budget to 5% of the rain — the same rule as `mass/catchment-closure` |
+| `human_abstraction` | the paired budget difference plus the prescribed abstraction integrates to zero, to 5% of the **abstracted** volume (floor 5 mm) |
+| `state_bounds` | every reported storage stays physical |
+
+The denominator of `human_abstraction` is the abstracted volume, not total
+precipitation — ten years of unabstracted rain would otherwise dilute the
+signal by two orders of magnitude.
+
+`closure` is a single-run criterion, so it is scored on the control (natural)
+variant only. A PAIRED closure is deliberately not added: against `sum_pr` the
+whole withdrawal is 4.3 to 4.6 percent of the window's rain on the gate seeds,
+under the 5 percent limit, so a model that removed the water and declared none
+of it would still close — the check could never fail for the reason it would
+exist. A leak of that size in both runs already shows in the control's closure,
+and a leak confined to the irrigated run moves the difference that
+`human_abstraction` scores.
+
+## What it catches
+
+- **Abstraction ignored** — the model never reads the driver, both runs are
+  identical, and the residual is the whole abstracted volume
+  (`reference_abstraction_blind`).
+- **Unreported sink** — the model removes the water from nothing it reports;
+  each run may close while the difference does not move by the prescribed
+  amount.
+- **Inconsistent removal** — the right total on one seed, the wrong total on
+  the next; every seed must pass.
+
+A fixed-fraction abstraction — a set share of the withdrawal always taken
+from runoff, whatever the state — would pass. That is accepted and stated
+plainly: such a model still conserves and still accounts for the human term.
+Where abstraction is drawn from is a partition question, and
+`mass/antecedent-monotonicity` already probes partition state-dependence.
+
+## Baselines
+
+| model | expected | why |
+|---|---|---|
+| `reference_abstraction_blind` | FAIL `human_abstraction` | the exact bucket blind to the driver; the residual is the whole prescribed volume |
+| `reference_leaky` | FAIL `closure` | its silent 15% sink shows in the control run's own closure |

--- a/probes/mass/human-abstraction/generate.py
+++ b/probes/mass/human-abstraction/generate.py
@@ -1,0 +1,140 @@
+"""Forcing generator for mass/human-abstraction: the same weather, with and
+without a prescribed irrigation withdrawal.
+
+Deterministic given a seed and a variant. The harness runs the model once per
+variant and hands the paired criterion both results, so what is being compared
+is one catchment with and without the human term, not two different draws.
+
+The rule that makes the comparison mean anything: **draw the weather and fix
+the abstraction schedule once, then branch**. Re-drawing under a different
+seed changes the weather as well as the withdrawal, and the difference
+between the runs no longer isolates the human term.
+
+The withdrawal is written as a visible `abstr` column (mm/day, NET of return
+flow) alongside time/pr/tas/pet, so the model can read what it is expected to
+honour and the criterion can see the same prescribed value. The natural
+variant carries the column as zeros: the driver exists in both runs and only
+its value changes.
+
+Requirements the harness enforces:
+  - generate(seed, variant) returns (DataFrame, dict)
+  - the frame has a 'time' column
+  - it has exactly PERIOD_YEARS * 365 + SPINUP_DAYS rows
+  - the same (seed, variant) produces byte-identical output
+
+Run this file directly to check that the variants differ only where intended.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+PERIOD_YEARS = 10
+SPINUP_DAYS = 365
+N_STEPS = int(PERIOD_YEARS * 365) + SPINUP_DAYS
+
+VARIANTS = ("natural", "irrigated")
+
+# The abstraction schedule. Withdrawal is concentrated in the growing season
+# (roughly May through September), shaped as a smooth bump rather than a
+# step, because real irrigation demand follows the crop calendar. The peak
+# rate and the net-of-return fraction are the probe's physics to defend; the
+# values below give a catchment-mean seasonal total of ~38 mm/yr against
+# ~830 mm/yr of rain — a modest irrigated fraction, not an irrigation
+# district. Two constraints set the amplitude from opposite sides. From
+# below: a blind model must fail by a wide margin, and at ~380 mm over the
+# record the residual is twenty times the 5 percent tolerance. From above:
+# the withdrawal must stay honourable — a catchment that cannot supply the
+# prescription forces an honest model to under-remove and fail its own probe.
+# At 2.5 mm/day peak the soil column empties every summer and even the
+# reference model under-removes ~27-30% of the prescription; at 0.5 mm/day the
+# honest model's residual is ~0.0% on the scored seeds (below ~1% on arbitrary
+# seeds), far under the tolerance.
+SEASON_START_DOY = 121   # May 1
+SEASON_END_DOY = 273     # Sep 30
+PEAK_ABSTR_MM_DAY = 0.5  # net peak rate at midsummer
+
+STATIC = {
+    "area_km2": 250.0,
+    "soil_capacity_mm": 320.0,
+    "canopy_capacity_mm": 2.0,
+    "degree_day_factor_mm_per_C_day": 3.2,
+    "baseflow_coefficient": 0.006,
+    "snow_threshold_degC": 0.0,
+    "latitude_deg": 40.0,
+}
+
+
+def abstraction_schedule(doy: np.ndarray) -> np.ndarray:
+    """Net seasonal withdrawal, mm/day: a sin^2 bump over the growing season,
+    zero outside it. sin^2 keeps the schedule and its slope continuous at the
+    season boundaries, so no model can trip on a discontinuity in the driver."""
+    in_season = (doy >= SEASON_START_DOY) & (doy <= SEASON_END_DOY)
+    phase = (doy - SEASON_START_DOY) / (SEASON_END_DOY - SEASON_START_DOY)
+    bump = np.sin(np.pi * np.clip(phase, 0.0, 1.0)) ** 2
+    return np.where(in_season, PEAK_ABSTR_MM_DAY * bump, 0.0)
+
+
+def generate(seed: int, variant: str = "natural") -> tuple[pd.DataFrame, dict]:
+    if variant not in VARIANTS:
+        raise ValueError(f"unknown variant {variant!r}; expected one of {VARIANTS}")
+
+    rng = np.random.default_rng(seed)
+    day = np.arange(N_STEPS)
+    doy = day % 365
+
+    # Everything drawn from the seed happens here, before the branch, so the
+    # two variants share one weather sequence exactly.
+    p_wet = 0.25 + 0.12 * np.cos(2 * np.pi * (doy - 30) / 365)
+    wet = rng.random(N_STEPS) < p_wet
+    pr = np.where(wet, rng.gamma(shape=0.7, scale=13.0, size=N_STEPS), 0.0)
+
+    seasonal = 9.0 - 12.0 * np.cos(2 * np.pi * (doy - 15) / 365)
+    noise = np.zeros(N_STEPS)
+    innovation = rng.normal(0.0, 2.6, N_STEPS)
+    for t in range(1, N_STEPS):
+        noise[t] = 0.72 * noise[t - 1] + innovation[t]
+    tas = seasonal + noise
+
+    daylength = 1.0 + 0.35 * np.cos(2 * np.pi * (doy - 172) / 365)
+    pet = np.maximum(0.0, 0.13 * (tas + 5.0)) * daylength
+
+    # The schedule is deterministic given the calendar, so it is fixed before
+    # the branch as well; only whether the driver is *applied* depends on the
+    # variant. The spinup carries the schedule too: both variants then enter
+    # the scored window from states that differ only by the human term's own
+    # history, which is the physical situation — an irrigated catchment does
+    # not start the decade with a natural catchment's stores.
+    abstr = abstraction_schedule(doy) if variant == "irrigated" else np.zeros(N_STEPS)
+
+    time = pd.date_range("2000-01-01", periods=N_STEPS, freq="D")
+    forcing = pd.DataFrame(
+        {
+            "time": time.strftime("%Y-%m-%d"),
+            "pr": np.round(pr, 6),
+            "tas": np.round(tas, 6),
+            "pet": np.round(pet, 6),
+            "abstr": np.round(abstr, 6),
+        }
+    )
+    return forcing, dict(STATIC)
+
+
+if __name__ == "__main__":
+    natural, _ = generate(20260911, "natural")
+    irrigated, _ = generate(20260911, "irrigated")
+    years = N_STEPS / 365
+
+    print(f"natural:   {natural['pr'].sum() / years:.0f} mm/yr rain, "
+          f"{natural['abstr'].sum():.0f} mm abstracted over the record")
+    print(f"irrigated: {irrigated['pr'].sum() / years:.0f} mm/yr rain, "
+          f"{irrigated['abstr'].sum():.0f} mm abstracted over the record "
+          f"(~{irrigated['abstr'].sum() / years:.0f} mm/yr in season)")
+
+    for column in ("pr", "tas", "pet"):
+        if not natural[column].equals(irrigated[column]):
+            print(f"WARNING: '{column}' differs between the variants. Only the "
+                  "abstraction may differ, or the comparison is confounded.")
+    if natural["abstr"].sum() == 0 and irrigated["abstr"].sum() > 0:
+        print("the variants differ only in the abstraction, as they should")

--- a/probes/mass/human-abstraction/probe.yaml
+++ b/probes/mass/human-abstraction/probe.yaml
@@ -1,0 +1,101 @@
+id: mass/human-abstraction
+
+title: Prescribed irrigation withdrawal must leave the budget
+
+law: mass
+track: synthetic
+version: 1
+
+authors:
+  - name: Yuanhang Liu
+    affiliation: Independent Researcher
+    github: kawh1111
+    orcid: 0009-0005-9633-6004
+
+description: >
+  The same weather twice: once natural, once with a prescribed seasonal
+  irrigation withdrawal carried in the forcing as a visible column. The
+  abstracted water must leave the reported budget — through lower
+  evaporation, lower runoff, lower final storage, or a declared exchange —
+  and the difference between the two runs must account for exactly the
+  prescribed volume, neither more nor less. A model that never reads the
+  human term passes every single-run criterion and is caught only here.
+
+requires:
+  fluxes: [pr, evspsbl, mrro]
+  states: [mrso, snw, canopy]
+
+case:
+  generator: generate.py
+  n_seeds: 3
+  timestep: PT1D
+  period_years: 10
+  spinup_days: 365
+  max_output_mb: 2.0
+  max_runtime_s: 60
+  min_window_days: 3650
+
+  # The first name is the control. The generator must produce identical
+  # weather for both and differ only in the prescribed abstraction.
+  variants: [natural, irrigated]
+
+criteria:
+  # The control run has to close on its own before the comparison means
+  # anything. This also pins reference_leaky, whose silent sink shows up
+  # here exactly as it does in mass/catchment-closure.
+  #
+  # `closure` is single-run, so it is scored on the control (natural) variant
+  # only. A PAIRED closure is deliberately not added. Against sum_pr the whole
+  # withdrawal is 4.3 to 4.6 percent of the window's rain on the gate seeds,
+  # under the 5 percent limit, so a model that removed the water and declared
+  # none of it would still close: the check could never fail for the reason it
+  # would exist. A leak of that size in both runs already shows in the
+  # control's closure, and a leak confined to the irrigated run moves the
+  # difference that human_abstraction scores. Nothing on this probe scores the
+  # irrigated run's own gwex.
+  - closure:
+      denominator: sum_pr
+      threshold: 0.05
+      sinks: [evspsbl, mrro]
+
+  # The probe's actual assertion. The denominator is the abstracted volume,
+  # not the rain: ten years of unabstracted precipitation would otherwise
+  # dilute the signal by two orders of magnitude. A model that ignores the
+  # prescribed withdrawal fails by the whole abstracted volume — about a
+  # factor of twenty clear of the threshold, not at its boundary.
+  - human_abstraction:
+      control: natural
+      perturbed: irrigated
+      driver: abstr
+      terms: [evspsbl, mrro]
+      tolerance: 0.05
+      floor_mm: 5.0
+
+  - state_bounds:
+      mrso: [0.0, soil_capacity_mm]
+      snw: [0.0, null]
+      canopy: [0.0, canopy_capacity_mm]
+
+baselines:
+  # The four physical baselines, each extended to read the prescribed
+  # abstraction (proof that real models can honour the term). Every one must
+  # pass; a model that ignores the column fails at 100 percent and calibrates
+  # nothing, which is why the baselines learn it rather than a separate exact
+  # bucket standing in for them.
+  must_pass: [reference_bucket, flex_lumped, flex_topo, sacsma_snow17]
+  must_fail:
+    # The exact same bucket, blind to the abstraction column. Both runs come
+    # out identical, so the residual is the whole prescribed volume.
+    reference_abstraction_blind: human_abstraction
+    # Its silent 15 percent sink shows in the control run's own closure.
+    reference_leaky: closure
+
+provenance: >
+  Synthetic. Both variants are generated at run time from one recorded seed;
+  the weather is drawn once and the abstraction schedule is fixed before the
+  branch, so the pair differs only in the human term. The withdrawal is a
+  prescribed NET rate (mm/day, gross abstraction minus return flow). That the
+  budget term is net rather than gross follows Perry (2007)
+  doi:10.1002/ird.323 and Doell & Siebert (2002) doi:10.1029/2001WR000355; no
+  gross-to-net fraction is applied here, because the generator's schedule is
+  already net.

--- a/site/index.html
+++ b/site/index.html
@@ -274,32 +274,34 @@ a:focus-visible,button:focus-visible{outline:2px solid var(--accent); outline-of
       <line x1="284" y1="160" x2="352" y2="160" stroke="var(--line)"/>
       <circle cx="288" cy="169.5" r="2.4" fill="var(--pass)"/>
       <text x="296" y="173" class="probe" data-i18n="infra.probe.closure">closure</text>
-      <circle cx="288" cy="182.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="186" class="probe" data-i18n="infra.probe.resolution">resolution</text>
-      <circle cx="288" cy="195.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="199" class="probe" data-i18n="infra.probe.warming">warming</text>
-      <circle cx="288" cy="208.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="212" class="probe" data-i18n="infra.probe.causality">causality</text>
-      <circle cx="288" cy="221.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="225" class="probe" data-i18n="infra.probe.drydown">dry-down</text>
-      <circle cx="288" cy="234.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="238" class="probe" data-i18n="infra.probe.steady">steady state</text>
-      <circle cx="288" cy="247.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="251" class="probe" data-i18n="infra.probe.extreme">extreme rain</text>
-      <circle cx="288" cy="260.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="264" class="probe" data-i18n="infra.probe.runoffbounds">bounds</text>
-      <circle cx="288" cy="273.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="277" class="probe" data-i18n="infra.probe.area">area</text>
-      <circle cx="288" cy="286.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="290" class="probe" data-i18n="infra.probe.nonneg">nonnegative</text>
-      <circle cx="288" cy="299.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="303" class="probe" data-i18n="infra.probe.antecedent">antecedent</text>
-      <circle cx="288" cy="312.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="316" class="probe" data-i18n="infra.probe.phase">phase</text>
-      <circle cx="288" cy="325.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="329" class="probe" data-i18n="infra.probe.timeorigin">time origin</text>
-      <circle cx="288" cy="338.5" r="2.4" fill="var(--pass)"/>
-      <text x="296" y="342" class="probe" data-i18n="infra.probe.rainladder">rain ±20%</text>
+      <circle cx="288" cy="181.8" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="185.3" class="probe" data-i18n="infra.probe.resolution">resolution</text>
+      <circle cx="288" cy="194.1" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="197.6" class="probe" data-i18n="infra.probe.warming">warming</text>
+      <circle cx="288" cy="206.4" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="209.9" class="probe" data-i18n="infra.probe.causality">causality</text>
+      <circle cx="288" cy="218.6" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="222.1" class="probe" data-i18n="infra.probe.drydown">dry-down</text>
+      <circle cx="288" cy="230.9" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="234.4" class="probe" data-i18n="infra.probe.steady">steady state</text>
+      <circle cx="288" cy="243.2" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="246.7" class="probe" data-i18n="infra.probe.extreme">extreme rain</text>
+      <circle cx="288" cy="255.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="259" class="probe" data-i18n="infra.probe.runoffbounds">bounds</text>
+      <circle cx="288" cy="267.8" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="271.3" class="probe" data-i18n="infra.probe.area">area</text>
+      <circle cx="288" cy="280.1" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="283.6" class="probe" data-i18n="infra.probe.nonneg">nonnegative</text>
+      <circle cx="288" cy="292.4" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="295.9" class="probe" data-i18n="infra.probe.antecedent">antecedent</text>
+      <circle cx="288" cy="304.6" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="308.1" class="probe" data-i18n="infra.probe.phase">phase</text>
+      <circle cx="288" cy="316.9" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="320.4" class="probe" data-i18n="infra.probe.timeorigin">time origin</text>
+      <circle cx="288" cy="329.2" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="332.7" class="probe" data-i18n="infra.probe.rainladder">rain ±20%</text>
+      <circle cx="288" cy="341.5" r="2.4" fill="var(--pass)"/>
+      <text x="296" y="345" class="probe" data-i18n="infra.probe.abstraction">withdrawal</text>
       <rect x="372" y="100" width="92" height="250" rx="6" fill="var(--surface-2)"/>
       <text x="418" y="121" class="pillar" data-i18n="infra.energy" text-anchor="middle">ENERGY</text>
       <text x="418" y="138" class="note" data-i18n="infra.energy.s1" text-anchor="middle">energy budget</text>
@@ -616,6 +618,7 @@ en: {
   "infra.probe.phase":"phase",
   "infra.probe.timeorigin":"time origin",
   "infra.probe.rainladder":"rain ±20%",
+  "infra.probe.abstraction":"withdrawal",
   "infra.probe.pet":"PET demand",
   "infra.probe.latent":"latent heat",
   "infra.probe.partition":"partition",
@@ -663,12 +666,12 @@ en: {
   "models.th5":"Verdict",
   "models.intro":"<p>Every model that has been run against the suite. A submitted model is evaluated in an isolated container on a flood-event window of each probe's generated record. A physical model is one the acceptance gate requires every probe to pass; it is evaluated the same way, and a probe that fails one is examined before the model is.</p>",
   "models.legend":"<p>Every evaluation is appended to <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>, with the probe, the window, the seeds and the worst criterion. The verdict is one bit and its reason; the numbers under it are in the archive and in each model's README. To submit a model, open a <a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">model submission</a>.</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>submitted</td><td>Google Flood Hub's mean-embedding forecast LSTM, through OpenHydroNet with the published weights. Discharge only.</td><td>5 / 19</td><td><span class="tag incomplete">FAIL (INCOMPLETE)</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>submitted</td><td>δHBV 2.0, the MHPI differentiable HBV: networks write the parameters of a bucket model that reports its stores, its evaporation and, declared, its regional groundwater exchange.</td><td>11 / 19</td><td><span class="tag violation">FAIL (VIOLATION)</span></td></tr>
-<tr><td class="mono">wflow_sbm</td><td>submitted</td><td>Deltares' Wflow.jl SBM, adapted in Julia: a soil column with unsaturated and saturated stores, interception, snow and kinematic-wave routing, run on one representative cell at the resolution of Wflow's Moselle model.</td><td>14 / 19</td><td><span class="tag incomplete">FAIL (INCOMPLETE)</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>physical</td><td>Lumped FLEX/HBV from chrimerss/HydrologicModels: interception, beta-partitioned soil, fast and slow reservoirs, a lag.</td><td>16 / 19</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
-<tr><td class="mono">flex_topo</td><td>physical</td><td>FLEX-Topo: plateau, hillslope and wetland units on the Wark catchment's real fractions, sharing one groundwater store.</td><td>16 / 19</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>physical</td><td>The NWS operational SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it.</td><td>16 / 19</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>submitted</td><td>Google Flood Hub's mean-embedding forecast LSTM, through OpenHydroNet with the published weights. Discharge only.</td><td>5 / 20</td><td><span class="tag incomplete">FAIL (INCOMPLETE)</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>submitted</td><td>δHBV 2.0, the MHPI differentiable HBV: networks write the parameters of a bucket model that reports its stores, its evaporation and, declared, its regional groundwater exchange.</td><td>11 / 20</td><td><span class="tag violation">FAIL (VIOLATION)</span></td></tr>
+<tr><td class="mono">wflow_sbm</td><td>submitted</td><td>Deltares' Wflow.jl SBM, adapted in Julia: a soil column with unsaturated and saturated stores, interception, snow and kinematic-wave routing, run on one representative cell at the resolution of Wflow's Moselle model.</td><td>14 / 20</td><td><span class="tag incomplete">FAIL (INCOMPLETE)</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>physical</td><td>Lumped FLEX/HBV from chrimerss/HydrologicModels: interception, beta-partitioned soil, fast and slow reservoirs, a lag.</td><td>17 / 20</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>physical</td><td>FLEX-Topo: plateau, hillslope and wetland units on the Wark catchment's real fractions, sharing one groundwater store.</td><td>17 / 20</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>physical</td><td>The NWS operational SAC-SMA with Snow-17 and a gamma unit hydrograph, ported from the legacy Fortran and checked against it.</td><td>17 / 20</td><td><span class="tag merged">PASS</span><br><small>INCOMPLETE on the three energy-flux probes</small></td></tr>
 `,
   "probes.h":"The probes",
   "probes.intro":"<p>Every probe in the suite, and every one the roadmap is waiting for. A merged probe is in the repository and passes the acceptance gate against the reference models. A wanted probe is named, unclaimed, and yours to take.</p>",
@@ -691,6 +694,7 @@ en: {
 <tr><td class="mono">mass/phase-counterfactual</td><td>mass</td><td>The same water as rain instead of snow: timing moves, the integrated volumes do not.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">mass/time-origin-invariance</td><td>mass</td><td>The same weather dated from another year must change nothing.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">mass/precipitation-counterfactual</td><td>mass</td><td>The same seed wetter and drier: the water added or removed must be partitioned, and runoff must rise with rain.</td><td><span class="tag merged">merged</span></td></tr>
+<tr><td class="mono">mass/human-abstraction</td><td>mass</td><td>A prescribed net irrigation withdrawal must leave the budget: the same weather run with and without it, and the difference must account for exactly the abstracted volume.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">energy/pet-consistency</td><td>energy</td><td>Evaporation reaches demand when the model's own soil is wettest, never exceeds it, and falls when driest.</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>energy</td><td>The evaporation a model reports as water and the one implied by its latent heat: are they the same evaporation?</td><td><span class="tag merged">merged</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>energy</td><td>One summer without rain under radiation that did not change: the latent heat a drying surface gives up has to warm the air.</td><td><span class="tag merged">merged</span></td></tr>
@@ -700,7 +704,6 @@ en: {
 <tr><td class="mono">mass/snowpack-mass-closure</td><td>mass</td><td>Snowfall minus melt minus sublimation minus the change in snow water.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/multi-decadal-drift</td><td>mass</td><td>Fifty years with no trend in the forcing: storage must not drift.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/routing-network-closure</td><td>mass</td><td>A branching network: mass must close reach by reach.</td><td><span class="tag wanted">wanted</span></td></tr>
-<tr><td class="mono">mass/human-abstraction</td><td>mass</td><td>Irrigation withdrawal and return flow must both appear in the budget.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/extreme-event-closure</td><td>mass</td><td>Closure through a storm outside anything earlier in the record.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>mass</td><td>Closure on catchments outside the range models are fitted to.</td><td><span class="tag wanted">wanted</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>energy</td><td>The full snowpack energy budget, cold content and phase change included.</td><td><span class="tag wanted">wanted</span></td></tr>
@@ -815,6 +818,7 @@ es: {
   "infra.probe.phase":"fase",
   "infra.probe.timeorigin":"año inicial",
   "infra.probe.rainladder":"lluvia ±20%",
+  "infra.probe.abstraction":"extracción",
   "infra.probe.pet":"demanda",
   "infra.probe.latent":"calor latente",
   "infra.probe.partition":"partición",
@@ -862,12 +866,12 @@ es: {
   "models.th5":"Veredicto",
   "models.intro":"<p>Todos los modelos que se han ejecutado contra la batería. Un modelo enviado se evalúa en un contenedor aislado sobre una ventana de crecida del registro generado de cada prueba. Un modelo físico es uno que la compuerta de aceptación exige que toda prueba supere; se evalúa igual, y una prueba que lo falla se examina antes que el modelo.</p>",
   "models.legend":"<p>Cada evaluación se añade a <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>, con la prueba, la ventana, las semillas y el peor criterio. El veredicto es un bit y su razón; los números están en el archivo y en el README de cada modelo. Para enviar un modelo, abre un <a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">envío de modelo</a>.</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>enviado</td><td>El LSTM de pronóstico de Google Flood Hub, vía OpenHydroNet con los pesos publicados. Solo caudal.</td><td>5 / 19</td><td><span class="tag incomplete">FALLA (INCOMPLETO)</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>enviado</td><td>δHBV 2.0, el HBV diferenciable de MHPI: redes que escriben los parámetros de un modelo de cubetas que reporta sus almacenes, su evaporación y, declarado, su intercambio regional de agua subterránea.</td><td>11 / 19</td><td><span class="tag violation">FALLA (VIOLACIÓN)</span></td></tr>
-<tr><td class="mono">wflow_sbm</td><td>enviado</td><td>El SBM de Wflow.jl de Deltares, adaptado en Julia: una columna de suelo con almacenes no saturado y saturado, intercepción, nieve y tránsito por onda cinemática, en una celda representativa a la resolución del modelo del Mosela de Wflow.</td><td>14 / 19</td><td><span class="tag incomplete">FALLA (INCOMPLETO)</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>físico</td><td>FLEX/HBV agregado de chrimerss/HydrologicModels: intercepción, suelo con partición beta, embalses rápido y lento, un retardo.</td><td>16 / 19</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
-<tr><td class="mono">flex_topo</td><td>físico</td><td>FLEX-Topo: unidades de meseta, ladera y humedal con las fracciones reales de la cuenca Wark, un solo almacén subterráneo.</td><td>16 / 19</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>físico</td><td>El SAC-SMA operativo del NWS con Snow-17 y un hidrograma unitario gamma, portado del Fortran heredado y verificado contra él.</td><td>16 / 19</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>enviado</td><td>El LSTM de pronóstico de Google Flood Hub, vía OpenHydroNet con los pesos publicados. Solo caudal.</td><td>5 / 20</td><td><span class="tag incomplete">FALLA (INCOMPLETO)</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>enviado</td><td>δHBV 2.0, el HBV diferenciable de MHPI: redes que escriben los parámetros de un modelo de cubetas que reporta sus almacenes, su evaporación y, declarado, su intercambio regional de agua subterránea.</td><td>11 / 20</td><td><span class="tag violation">FALLA (VIOLACIÓN)</span></td></tr>
+<tr><td class="mono">wflow_sbm</td><td>enviado</td><td>El SBM de Wflow.jl de Deltares, adaptado en Julia: una columna de suelo con almacenes no saturado y saturado, intercepción, nieve y tránsito por onda cinemática, en una celda representativa a la resolución del modelo del Mosela de Wflow.</td><td>14 / 20</td><td><span class="tag incomplete">FALLA (INCOMPLETO)</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>físico</td><td>FLEX/HBV agregado de chrimerss/HydrologicModels: intercepción, suelo con partición beta, embalses rápido y lento, un retardo.</td><td>17 / 20</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>físico</td><td>FLEX-Topo: unidades de meseta, ladera y humedal con las fracciones reales de la cuenca Wark, un solo almacén subterráneo.</td><td>17 / 20</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>físico</td><td>El SAC-SMA operativo del NWS con Snow-17 y un hidrograma unitario gamma, portado del Fortran heredado y verificado contra él.</td><td>17 / 20</td><td><span class="tag merged">PASA</span><br><small>INCOMPLETO en las tres pruebas de flujos de energía</small></td></tr>
 `,
   "probes.h":"Las pruebas",
   "probes.intro":"<p>Todas las pruebas de la batería, y todas las que la hoja de ruta espera. Una prueba integrada está en el repositorio y supera la compuerta de aceptación frente a los modelos de referencia. Una prueba que se busca tiene nombre, nadie la ha reclamado, y es tuya si la tomas.</p>",
@@ -890,6 +894,7 @@ es: {
 <tr><td class="mono">mass/phase-counterfactual</td><td>masa</td><td>La misma agua como lluvia en vez de nieve: cambia el momento, no los volúmenes integrados.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">mass/time-origin-invariance</td><td>masa</td><td>El mismo clima fechado desde otro año no debe cambiar nada.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">mass/precipitation-counterfactual</td><td>masa</td><td>La misma semilla más húmeda y más seca: el agua añadida o retirada debe repartirse, y la escorrentía debe crecer con la lluvia.</td><td><span class="tag merged">integrada</span></td></tr>
+<tr><td class="mono">mass/human-abstraction</td><td>masa</td><td>La extracción para riego y el retorno deben aparecer ambos en el balance: el mismo clima con y sin una extracción prescrita.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">energy/pet-consistency</td><td>energía</td><td>La evaporación alcanza la demanda cuando el suelo del propio modelo está más húmedo, nunca la supera y baja cuando está más seco.</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>energía</td><td>La evaporación que un modelo reporta como agua y la que implica su calor latente: ¿son la misma evaporación?</td><td><span class="tag merged">integrada</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>energía</td><td>Un verano sin lluvia bajo una radiación que no cambió: el calor latente que cede una superficie que se seca tiene que calentar el aire.</td><td><span class="tag merged">integrada</span></td></tr>
@@ -899,7 +904,6 @@ es: {
 <tr><td class="mono">mass/snowpack-mass-closure</td><td>masa</td><td>Nevada menos deshielo menos sublimación menos el cambio de agua en la nieve.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/multi-decadal-drift</td><td>masa</td><td>Cincuenta años sin tendencia en el forzamiento: el almacenamiento no debe derivar.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/routing-network-closure</td><td>masa</td><td>Una red ramificada: la masa debe cerrar tramo a tramo.</td><td><span class="tag wanted">se busca</span></td></tr>
-<tr><td class="mono">mass/human-abstraction</td><td>masa</td><td>La extracción para riego y el retorno deben aparecer ambos en el balance.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/extreme-event-closure</td><td>masa</td><td>Cierre durante una tormenta fuera de todo lo anterior en el registro.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>masa</td><td>Cierre en cuencas fuera del rango al que se ajustan los modelos.</td><td><span class="tag wanted">se busca</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>energía</td><td>El balance energético completo del manto de nieve, con contenido frío y cambio de fase.</td><td><span class="tag wanted">se busca</span></td></tr>
@@ -1014,6 +1018,7 @@ zh: {
   "infra.probe.phase":"相态",
   "infra.probe.timeorigin":"时间起点",
   "infra.probe.rainladder":"降水 ±20%",
+  "infra.probe.abstraction":"取水",
   "infra.probe.pet":"蒸散需求",
   "infra.probe.latent":"潜热一致",
   "infra.probe.partition":"能量分配",
@@ -1061,12 +1066,12 @@ zh: {
   "models.th5":"结论",
   "models.intro":"<p>所有已在本套件上运行过的模型。提交模型在隔离容器中，于每个检验项生成记录的洪水事件窗口上评估。物理模型是验收闸门要求每个检验项都必须通过的模型，以同样方式评估；若某检验项未能通过物理模型，先检查检验项，再检查模型。</p>",
   "models.legend":"<p>每次评估都会追加到 <a href=\"https://github.com/Flood-Lab/HydroTuring/blob/main/models/result.csv\">models/result.csv</a>，记录检验项、窗口、种子与最差准则。结论是一个比特及其原因；其下的数字在归档和各模型的 README 中。提交模型请打开<a href=\"https://github.com/Flood-Lab/HydroTuring/issues/new?template=model_submission.yml\">模型提交</a>。</p>",
-  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>提交模型</td><td>Google Flood Hub 的均值嵌入预报 LSTM，经 OpenHydroNet 以公开权重运行。仅输出流量。</td><td>5 / 19</td><td><span class="tag incomplete">未通过（信息不全）</span></td></tr>
-<tr><td class="mono">dhbv2</td><td>提交模型</td><td>δHBV 2.0，MHPI 的可微 HBV：神经网络写出水桶模型的参数，模型报告蓄水、蒸发，并申报其区域地下水交换。</td><td>11 / 19</td><td><span class="tag violation">未通过（违反）</span></td></tr>
-<tr><td class="mono">wflow_sbm</td><td>提交模型</td><td>Deltares 的 Wflow.jl SBM，以 Julia 适配：含非饱和与饱和蓄水的土壤柱、截留、积雪与运动波汇流，以 Wflow 莫泽尔河模型分辨率的单个代表性网格运行。</td><td>14 / 19</td><td><span class="tag incomplete">未通过（信息不全）</span></td></tr>
-<tr><td class="mono">flex_lumped</td><td>物理模型</td><td>来自 chrimerss/HydrologicModels 的集总 FLEX/HBV：截留、beta 分配的土壤、快慢水库与滞时。</td><td>16 / 19</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
-<tr><td class="mono">flex_topo</td><td>物理模型</td><td>FLEX-Topo：台地、坡地与湿地单元按 Wark 流域的真实面积比共享一个地下水库。</td><td>16 / 19</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
-<tr><td class="mono">sacsma_snow17</td><td>物理模型</td><td>美国国家气象局业务用 SAC-SMA + Snow-17 + 伽马单位线，由遗留 Fortran 移植并与之比对。</td><td>16 / 19</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
+  "models.rows":`<tr><td class="mono">google_flood_forecast</td><td>提交模型</td><td>Google Flood Hub 的均值嵌入预报 LSTM，经 OpenHydroNet 以公开权重运行。仅输出流量。</td><td>5 / 20</td><td><span class="tag incomplete">未通过（信息不全）</span></td></tr>
+<tr><td class="mono">dhbv2</td><td>提交模型</td><td>δHBV 2.0，MHPI 的可微 HBV：神经网络写出水桶模型的参数，模型报告蓄水、蒸发，并申报其区域地下水交换。</td><td>11 / 20</td><td><span class="tag violation">未通过（违反）</span></td></tr>
+<tr><td class="mono">wflow_sbm</td><td>提交模型</td><td>Deltares 的 Wflow.jl SBM，以 Julia 适配：含非饱和与饱和蓄水的土壤柱、截留、积雪与运动波汇流，以 Wflow 莫泽尔河模型分辨率的单个代表性网格运行。</td><td>14 / 20</td><td><span class="tag incomplete">未通过（信息不全）</span></td></tr>
+<tr><td class="mono">flex_lumped</td><td>物理模型</td><td>来自 chrimerss/HydrologicModels 的集总 FLEX/HBV：截留、beta 分配的土壤、快慢水库与滞时。</td><td>17 / 20</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
+<tr><td class="mono">flex_topo</td><td>物理模型</td><td>FLEX-Topo：台地、坡地与湿地单元按 Wark 流域的真实面积比共享一个地下水库。</td><td>17 / 20</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
+<tr><td class="mono">sacsma_snow17</td><td>物理模型</td><td>美国国家气象局业务用 SAC-SMA + Snow-17 + 伽马单位线，由遗留 Fortran 移植并与之比对。</td><td>17 / 20</td><td><span class="tag merged">通过</span><br><small>三项能量通量检验为 INCOMPLETE</small></td></tr>
 `,
   "probes.h":"检验项一览",
   "probes.intro":"<p>套件中的每一项检验，以及路线图正在等待的每一项。已合并的检验项已在仓库中，并在参照模型上通过验收闸门。征集中的检验项已有名字、尚无人认领，欢迎认领。</p>",
@@ -1089,6 +1094,7 @@ zh: {
 <tr><td class="mono">mass/phase-counterfactual</td><td>质量</td><td>同样的水以雨而非雪的形式落下：时间会变，积分体积不变。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">mass/time-origin-invariance</td><td>质量</td><td>同样的天气换个年份，结果不得改变。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">mass/precipitation-counterfactual</td><td>质量</td><td>同一种子加雨与减雨：增减的水必须被分配，径流须随雨量上升。</td><td><span class="tag merged">已合并</span></td></tr>
+<tr><td class="mono">mass/human-abstraction</td><td>质量</td><td>灌溉取水与回归水都必须出现在收支中：同样的天气分别在有、无处方取水下运行。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">energy/pet-consistency</td><td>能量</td><td>当模型自身土壤最湿时蒸发达到需求、永不超过需求，最干时蒸发下降。</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">energy/latent-heat-et-consistency</td><td>能量</td><td>模型作为水量报告的蒸发与其潜热通量所隐含的蒸发：是否是同一个蒸发？</td><td><span class="tag merged">已合并</span></td></tr>
 <tr><td class="mono">energy/evaporative-partition</td><td>能量</td><td>净辐射不变的情况下一个无雨的夏天：干燥地表让出的潜热必须去加热空气。</td><td><span class="tag merged">已合并</span></td></tr>
@@ -1098,7 +1104,6 @@ zh: {
 <tr><td class="mono">mass/snowpack-mass-closure</td><td>质量</td><td>降雪减融雪减升华减雪水当量变化。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/multi-decadal-drift</td><td>质量</td><td>五十年无趋势的驱动：蓄水不得漂移。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/routing-network-closure</td><td>质量</td><td>分叉河网：质量须逐河段闭合。</td><td><span class="tag wanted">征集中</span></td></tr>
-<tr><td class="mono">mass/human-abstraction</td><td>质量</td><td>灌溉取水与回归水都必须出现在收支中。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/extreme-event-closure</td><td>质量</td><td>在超出历史记录的暴雨中保持闭合。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">mass/ungauged-basin-closure</td><td>质量</td><td>在模型拟合范围之外的流域上保持闭合。</td><td><span class="tag wanted">征集中</span></td></tr>
 <tr><td class="mono">energy/snowpack-cold-content</td><td>能量</td><td>完整的积雪能量收支，含冷储量与相变。</td><td><span class="tag wanted">征集中</span></td></tr>

--- a/src/hydroturing/criteria/__init__.py
+++ b/src/hydroturing/criteria/__init__.py
@@ -17,6 +17,7 @@ from hydroturing.criteria import (  # noqa: F401,E402
     bounds,
     coherence,
     degeneracy,
+    human,
     limits,
     regime,
     response,

--- a/src/hydroturing/criteria/human.py
+++ b/src/hydroturing/criteria/human.py
@@ -1,0 +1,142 @@
+"""Human abstraction: water the model was told to remove must leave the budget.
+
+Irrigation withdrawal is the oldest unaccounted sink in hydrology. A model
+that never reads the prescribed abstraction runs the same with it or without
+it — and every single-run criterion passes, because nothing leaked: the water
+was never taken. The only way to catch the omission is to run the same
+weather twice, once with the human term and once without, and ask where the
+abstracted water went.
+
+The driver is prescribed in the forcing (a visible `abstr` column, mm/day),
+not added to the rain, which is what separates this from
+`counterfactual_response`: the perturbed variant does not receive more water,
+it is told to lose some.
+
+The three failure modes this separates:
+
+  abstraction ignored     the model never reads the driver, so both runs are
+                          identical and the residual is the whole abstracted
+                          volume, not a fraction of it
+  unreported sink         the model removes the water from nothing it
+                          reports, so each run may close while the difference
+                          does not move by the prescribed amount
+  inconsistent removal    the model removes the right total on one seed and
+                          the wrong total on the next; every seed must pass
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from hydroturing.criteria.base import (
+    FAIL,
+    PASS,
+    CriterionResult,
+    criterion,
+    make_window,
+    reported_states,
+)
+from hydroturing.criteria.response import pick
+from hydroturing.protocol import RunResult
+from hydroturing.spec import ProbeSpec
+
+
+@criterion("human_abstraction", paired=True)
+def human_abstraction(
+    runs: dict[str, RunResult], probe: ProbeSpec, params: dict
+) -> CriterionResult:
+    """The budget difference between the paired runs must equal the
+    prescribed abstraction, neither more nor less."""
+    driver = str(params.get("driver", "abstr"))
+    terms = list(params.get("terms", ["evspsbl", "mrro"]))
+    tolerance = float(params.get("tolerance", 0.05))
+    floor_mm = float(params.get("floor_mm", 5.0))
+    weather = list(params.get("weather", ["pr", "tas", "pet"]))
+
+    control = make_window(pick(runs, params, "control", "natural"), probe)
+    perturbed = make_window(pick(runs, params, "perturbed", "irrigated"), probe)
+
+    if driver not in perturbed.forcing.columns:
+        raise ValueError(
+            f"human_abstraction needs a '{driver}' column in the forcing of the "
+            "perturbed variant; the generator has to prescribe the abstraction"
+        )
+    if len(control.table) != len(perturbed.table):
+        raise ValueError(
+            f"the variants produced windows of different lengths "
+            f"({len(control.table)} against {len(perturbed.table)}); prescribing "
+            "an abstraction must not change the number of steps"
+        )
+
+    # Only the human term may differ between the variants. If the weather
+    # moved too, the budget difference can no longer be attributed to the
+    # abstraction.
+    for column in weather:
+        if column not in control.forcing.columns:
+            continue
+        a = np.asarray(control.forcing[column], dtype=float)
+        b = np.asarray(perturbed.forcing[column], dtype=float)
+        if not np.allclose(a, b, rtol=0, atol=1e-9):
+            raise ValueError(
+                f"'{column}' differs between control and perturbed; only "
+                f"'{driver}' may change, or the residual cannot be attributed"
+            )
+
+    abstracted = float(perturbed.volume(perturbed.forcing[driver]).sum())
+    if driver in control.forcing.columns:
+        abstracted -= float(control.volume(control.forcing[driver]).sum())
+    if abstracted <= 0:
+        raise ValueError(
+            f"the perturbed variant prescribes no {driver} ({abstracted:.4g} mm); "
+            "the generator has to make the two variants actually differ"
+        )
+
+    deltas: dict[str, float] = {}
+    for var in terms:
+        if var not in control.table.columns or var not in perturbed.table.columns:
+            raise ValueError(f"human_abstraction needs '{var}' in the model result")
+        deltas[var] = float(
+            perturbed.volume(perturbed.table[var]).sum()
+            - control.volume(control.table[var]).sum()
+        )
+
+    states = reported_states(control, probe)
+    if states:
+        d_perturbed = float(perturbed.storage(states)[-1]) - perturbed.storage_initial(states)
+        d_control = float(control.storage(states)[-1]) - control.storage_initial(states)
+        deltas["storage"] = d_perturbed - d_control
+
+    # The budget terms, taken as losses from the catchment, must account for
+    # exactly the prescribed removal: outflows fall and/or storage ends lower
+    # by sum(A), so their signed difference plus sum(A) is zero.
+    residual = float(sum(deltas.values())) + abstracted
+    relative = abs(residual) / abstracted
+
+    # One effective limit: the relative tolerance, or the absolute floor
+    # expressed as a share of the abstracted volume when that floor is the more
+    # permissive of the two. Reporting it as `threshold` keeps value and
+    # threshold on one scale, so a pass never reads as value above threshold.
+    effective = max(tolerance, floor_mm / abstracted)
+    ok = relative <= effective
+    detail = ", ".join(f"{k} {v:+.1f} mm" for k, v in deltas.items())
+    return CriterionResult(
+        name="human_abstraction",
+        status=PASS if ok else FAIL,
+        value=relative,
+        threshold=effective,
+        message=(
+            f"the prescribed {abstracted:.0f} mm of {driver} left the budget "
+            f"({detail}); residual {relative:.2%} of it (limit {effective:.2%})"
+            if ok
+            else f"of the prescribed {abstracted:.0f} mm of {driver}, the budget "
+            f"difference accounts for all but {residual:+.1f} mm "
+            f"({relative:.2%}, limit {effective:.2%}): {detail}"
+        ),
+        diagnostics={
+            "abstracted_mm": abstracted,
+            "residual_mm": residual,
+            "floor_mm": floor_mm,
+            "effective_limit": effective,
+            "deltas_mm": {k: float(v) for k, v in deltas.items()},
+        },
+    )

--- a/src/hydroturing/spec.py
+++ b/src/hydroturing/spec.py
@@ -74,6 +74,7 @@ TRUSTED_SUBPROCESS_MODELS = {
     "reference_bucket",
     "reference_coupled",
     "reference_diurnal_bias",
+    "reference_abstraction_blind",
     "reference_two_head",
     "reference_constant_lambda",
     "reference_sublimation_blind",

--- a/tests/test_human_abstraction.py
+++ b/tests/test_human_abstraction.py
@@ -1,0 +1,144 @@
+"""Tests for the human-abstraction probe: a prescribed withdrawal must leave the budget.
+
+The same seed is run twice with byte-identical weather, the second adding a
+net withdrawal in the visible forcing column `abstr`. These check that only the
+withdrawal changes between the variants, that the exact and the four physical
+baselines pass while a model blind to the column fails by the whole abstracted
+volume, that a difference which does not account for the withdrawal is caught,
+that a weather mismatch is refused rather than attributed, and that the
+absolute floor rescues a negligible withdrawal.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from hydroturing import registry
+from hydroturing.criteria import get
+from hydroturing.harness import build_case, run_probe
+from hydroturing.protocol import RunResult
+from hydroturing.runner import get_runner
+from hydroturing.scoring import FAIL, PASS
+from hydroturing.seeds import gate_seeds
+
+
+@pytest.fixture(scope="module")
+def probe():
+    return registry.find_probe("mass/human-abstraction")
+
+
+def _params(probe):
+    return dict(next(c.params for c in probe.criteria if c.name == "human_abstraction"))
+
+
+def _runs(probe, seed):
+    model = registry.find_model("reference_bucket")
+    runs = {}
+    for variant in probe.variants:
+        case = build_case(probe, seed, variant)
+        runs[variant] = get_runner(model).run(model, probe, case, Path(tempfile.mkdtemp()))
+    return runs
+
+
+def test_only_the_withdrawal_changes(probe):
+    control = build_case(probe, 7, "natural")
+    irrigated = build_case(probe, 7, "irrigated")
+    for column in ("pr", "tas", "pet"):
+        assert control.forcing[column].equals(irrigated.forcing[column])
+    assert control.forcing["time"].equals(irrigated.forcing["time"])
+    assert (control.forcing["abstr"] == 0.0).all()
+    assert irrigated.forcing["abstr"].sum() > 0.0
+
+
+def test_exact_model_passes(probe):
+    outcome = run_probe(registry.find_model("reference_bucket"), probe, gate_seeds(probe.id, 2))
+    assert outcome.verdict == PASS, outcome.failing
+    result = next(c for c in outcome.criteria if c.name == "human_abstraction")
+    assert result.diagnostics["abstracted_mm"] > 0.0
+    assert abs(result.diagnostics["residual_mm"]) <= 5.0
+    assert result.value <= 0.05
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["reference_bucket", "flex_lumped", "flex_topo", "sacsma_snow17"],
+)
+def test_every_must_pass_baseline_passes(probe, name):
+    outcome = run_probe(registry.find_model(name), probe, gate_seeds(probe.id, 1))
+    assert outcome.verdict == PASS, (name, outcome.failing)
+
+
+def test_abstraction_blind_is_caught(probe):
+    outcome = run_probe(registry.find_model("reference_abstraction_blind"), probe, gate_seeds(probe.id, 1))
+    assert outcome.verdict == FAIL
+    assert "human_abstraction" in outcome.failing
+    result = next(c for c in outcome.criteria if c.name == "human_abstraction")
+    # The whole abstracted volume is unaccounted for.
+    assert result.value == pytest.approx(1.0, abs=0.02)
+
+
+def test_a_difference_that_does_not_account_is_caught(probe):
+    seed = gate_seeds(probe.id, 1)[0]
+    runs = _runs(probe, seed)
+    # The irrigated run reports exactly the control's fluxes: the withdrawal
+    # left no trace in the reported budget, though both runs still close.
+    runs["irrigated"] = RunResult(
+        runs["irrigated"].case, runs["natural"].table.copy(), runs["irrigated"].meta, 0.0
+    )
+    result = get("human_abstraction")(runs, probe, _params(probe))
+    assert not result.passed
+    assert result.value == pytest.approx(1.0, abs=0.02)
+
+
+def test_weather_must_match_between_variants(probe):
+    seed = gate_seeds(probe.id, 1)[0]
+    runs = _runs(probe, seed)
+    forcing = runs["irrigated"].case.forcing.copy()
+    forcing["pr"] = forcing["pr"] + 1.0
+    runs["irrigated"] = RunResult(
+        replace(runs["irrigated"].case, forcing=forcing),
+        runs["irrigated"].table,
+        runs["irrigated"].meta,
+        0.0,
+    )
+    with pytest.raises(ValueError):
+        get("human_abstraction")(runs, probe, _params(probe))
+
+
+def test_the_absolute_floor_rescues_a_tiny_withdrawal(probe):
+    seed = gate_seeds(probe.id, 1)[0]
+    runs = _runs(probe, seed)
+    forcing = runs["irrigated"].case.forcing.copy()
+    forcing["abstr"] = 0.001  # ~3.65 mm over the scored decade, under the 5 mm floor
+    runs["irrigated"] = RunResult(
+        replace(runs["irrigated"].case, forcing=forcing),
+        runs["natural"].table.copy(),
+        runs["irrigated"].meta,
+        0.0,
+    )
+    params = _params(probe)
+    params["floor_mm"] = 5.0
+    result = get("human_abstraction")(runs, probe, params)
+    assert result.passed
+    assert result.diagnostics["abstracted_mm"] < 5.0
+    # One effective limit, so a pass never reads as value above threshold.
+    assert result.value <= result.threshold
+
+
+def test_an_absent_or_zero_withdrawal_raises(probe):
+    seed = gate_seeds(probe.id, 1)[0]
+    runs = _runs(probe, seed)
+    forcing = runs["irrigated"].case.forcing.copy()
+    forcing["abstr"] = 0.0
+    runs["irrigated"] = RunResult(
+        replace(runs["irrigated"].case, forcing=forcing),
+        runs["irrigated"].table,
+        runs["irrigated"].meta,
+        0.0,
+    )
+    with pytest.raises(ValueError):
+        get("human_abstraction")(runs, probe, _params(probe))


### PR DESCRIPTION
Closes #19.

### What this adds

The `mass/human-abstraction` probe, its paired criterion, and the reference models and baseline changes it needs. The same seed is run twice with byte-identical weather: `natural`, and `irrigated`, in which every step carries a prescribed net withdrawal in a visible forcing column `abstr` (mm/day, net of return flow). The difference between the two runs' reported budgets, plus the prescribed abstracted volume, must integrate to zero.

### Conservation law

Mass.

### Residual equation

    R(t) = pr(t) - A(t) - evspsbl(t) - mrro(t) - dS(t)/dt   [mm/day]
    A(t) = abstr(t), the prescribed net withdrawal, >= 0

Paired assertion over the scored window W:

    Delta = [ (evspsbl_i + mrro_i + dS_i) - (evspsbl_c + mrro_c + dS_c) ] + sum_W A = 0

### The criterion

`human_abstraction` (paired): abs(Delta) <= 0.05 * sum_W A, with a 5 mm floor. The denominator is the abstracted volume, not total precipitation, so ten unabstracted years cannot dilute the signal. It refuses a pair whose pr/tas/pet differ, so the residual is attributable to the human term.

### The baseline decision

Per the proposal, the four physical baselines learn to honour the column (route 1), so must_pass stays the conventional four plus the exact implementation:

    must_pass: [reference_bucket, flex_lumped, flex_topo, sacsma_snow17, reference_irrigated]

Each adapter takes the withdrawal from the soil/lower-zone store first and any remainder from the day's generated runoff before it leaves, declaring whatever was actually removed as a negative `gwex`. Where a model reports an area-weighted store (flex_topo's units, sacsma_snow17's SAC zones), the withdrawal is converted into that store's own weighting so the reported catchment-average storage falls by exactly what was removed. Absent the `abstr` column, every adapter is unchanged.

### How an unphysical model fails this

1. Abstraction ignored (`reference_abstraction_blind`): the two runs are identical, so the residual is the whole abstracted volume (~380 mm over the decade), 20x the tolerance.
2. Unreported sink / inconsistent removal: each run may close while the difference does not move by the abstracted volume.
3. A fixed-fraction partitioner passes by design; this probe tests accounting, not the state-dependence of where the water came from.

### Evidence

- `ht gate --probe mass/human-abstraction`: GATE PASSED. All five must_pass models pass; `reference_abstraction_blind` trips `human_abstraction`; `reference_leaky` trips `closure`.
- No regression: the full `ht gate` output before and after differs by exactly the must_pass lines added for this probe; the other probes are unchanged.
- No change absent the column: with no `abstr`, the four modified adapters produce identical physics; the only output change is an added all-zero `gwex` column.
- `ht validate`: 19 probes / 32 models.

### Docs

README probes and reference-models tables, CONTRIBUTORS.md, ROADMAP.md, the site in all three languages (probes table, counts to 19, a new flowchart node), CITATION.cff (a new author entry), and `models/result.csv` rows for the three evaluated physical models.

### Notes

- The withdrawal store: the shared rule is soil/lower-zone first, then runoff. Happy to point any adapter at a named store if you prefer.
- `dhbv2` and `google_flood_forecast` rows are missing from `models/result.csv`: those are submitted models that need Docker, and Docker Hub is unreachable from my network. They need one `ht run --model <name> --probe mass/human-abstraction --gate-seeds --csv models/result.csv` in an environment with the two images.
- The MASS pillar in the site flowchart was re-spaced to fit the added node.