### PR TITLE
Append archive rows with LF, not the csv module's CRLF

### DIFF
--- a/src/hydroturing/report.py
+++ b/src/hydroturing/report.py
@@ -287,7 +287,9 @@ def append_csv_rows(rows: list[dict[str, str]], path: str | Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     is_new = not path.exists() or path.stat().st_size == 0
     with open(path, "a", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS)
+        # The csv module ends rows in \r\n on every platform unless told
+        # otherwise, and the archive is committed as LF text.
+        writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS, lineterminator="\n")
         if is_new:
             writer.writeheader()
         writer.writerows(rows)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -233,6 +233,8 @@ def test_csv_archive_appends_one_row_per_probe(probe, tmp_path):
     assert rows[1]["seeds"] == str(seeds[0])
     # One header, however many appends.
     assert archive.read_text().count("run_date,") == 1
+    # LF on the header and the appended rows, not the csv module's CRLF.
+    assert b"\r\n" not in archive.read_bytes()
 
 
 def test_cli_window_and_csv_flags(probe, tmp_path, capsys):


### PR DESCRIPTION
## Summary

- **`append_csv_rows`** in `src/hydroturing/report.py` now passes `lineterminator="\n"` to its `csv.DictWriter`. The csv module's default is `\r\n`, so every row it appended ended in CRLF on every platform, macOS and Linux included. Both archive paths go through it: `ht run --csv` (`cmd_run` via `append_csv`) and `ht verify-adapter --csv` (`_archive_contract`). That is how rows 121–188 of `models/result.csv` came to be stored with CRLF (086694c, 607c199, d2345d5, f007811). The file is still opened with `newline=""`, so on Windows the `\n` is written as it is.
- **`tests/test_window.py`**: `test_csv_archive_appends_one_row_per_probe` appends twice, once writing the header to a new file and once appending to it, and now also asserts that the archive's bytes contain no `\r\n`.

## Verification

- Before the change the new assertion failed: the header and both rows ended in `\r\n` on macOS. After it, the test passes.
- End to end through the CLI, into one file: `ht run --model reference_bucket --probe mass/catchment-closure --seed 11 --csv X`, then `ht verify-adapter --model reference_streamflow_only --probe mass/catchment-closure --csv X`. The file has 3 lines and no `\r`.
- A `detail` value holding an embedded `\n`, a `"`, a `,`, a lone `\r` or an embedded `\r\n`, appended in two batches through the same `open` and `DictWriter` call, reads back unchanged with `csv.DictReader` on Python 3.12 and 3.13; each such field is quoted. In practice `detail` is one line: errors keep only their first line. The only reader of `models/result.csv` in the repository, `tests/test_docs_in_sync.py`, opens it with `newline=""` and accepts either ending.
- `pytest -q`: 333 passed (Python 3.12, `pip install -e '.[dev]'`).
- `ruff check` on the two files adds nothing: `report.py` has the same two ISC004 findings it has on main, and `test_window.py` is clean.

## Other writers checked

Nothing else that writes a committed file uses a csv writer or pandas `to_csv`.

- `src/hydroturing/protocol.py` writes the forcing with pandas `to_csv`, whose default is `os.linesep` (CRLF on Windows), into the model's `/io` directory. It is a runtime input, not committed, so it is left alone.
- Adapters, and the example in `docs/adapting-a-model.md`, write `output/result.csv` with `csv.DictWriter` inside `/io`: runtime files, left alone. The `to_csv` calls in the tests write to `tmp_path`.
- The one other committed CSV, `models/google_flood_forecast/event_window_seed598896396.csv`, is stored LF, and nothing in the repository writes it.
- Not csv, but the same effect on Windows only: `scripts/catchment_from_caravan.py` (`catchments/<id>.json`) and `src/hydroturing/scaffold.py` (probe and model files) write committed files with `Path.write_text`, which translates `\n` to `\r\n` on Windows. They write LF on macOS and Linux, and under #37's `* text=auto eol=lf` Git converts them on commit. Not changed here.

## Relation to #37

#37 (`normalize-line-endings`, still open) adds `* text=auto eol=lf`, renormalizes the 68 CRLF rows of `models/result.csv`, and fails CI when a text file is stored with CRLF. This PR fixes the writer that produced those rows. The two are independent, share no file and merge in either order, but they are related. With #37 alone, Git converts rows appended with CRLF when they are committed, but the working copy is left mixed and `git add` warns that CRLF will be replaced by LF. With this PR alone, new rows are LF, but the rows already stored with CRLF stay that way until #37 renormalizes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
