### PR TITLE
Wait for docker build to exit, not for its stderr to close

### DIFF
--- a/src/hydroturing/runner/docker_runner.py
+++ b/src/hydroturing/runner/docker_runner.py
@@ -8,14 +8,22 @@ It cannot fetch the probe definition, read the tolerance, or phone home.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 from hydroturing.runner.base import Runner, RunnerError
 from hydroturing.spec import ModelManifest, ProbeSpec
 
 IMAGE_PREFIX = "hydroturing"
+
+# Twice the fifteen minutes a first build of a heavy image has taken, and
+# inside the model workflow's 45-minute job, so CI reports a stuck build
+# rather than cancelling it. A cached rebuild takes seconds; this is for a
+# build that never exits, not a budget for a slow one.
+BUILD_TIMEOUT_S = 1800
 
 
 def image_tag(model: ModelManifest) -> str:
@@ -46,7 +54,12 @@ def require_docker() -> str:
     return docker
 
 
-def build(model: ModelManifest, quiet: bool = True, docker: str | None = None) -> str:
+def build(
+    model: ModelManifest,
+    quiet: bool = True,
+    docker: str | None = None,
+    timeout: float = BUILD_TIMEOUT_S,
+) -> str:
     docker = docker or require_docker()
     dockerfile = model.path / "Dockerfile"
     if not dockerfile.exists():
@@ -56,13 +69,35 @@ def build(model: ModelManifest, quiet: bool = True, docker: str | None = None) -
     argv = [docker, "build", "-t", tag, "-f", str(dockerfile), str(model.path)]
     if quiet:
         argv.insert(2, "--quiet")
-    proc = subprocess.run(argv, capture_output=True, text=True)
-    if proc.returncode != 0:
-        tail = (proc.stderr or "").strip().splitlines()[-20:]
-        raise RunnerError(
-            f"{model.name}: image build failed\n"
-            + "\n".join("    " + line for line in tail)
-        )
+    # The log goes to a file, not a pipe. On Docker Desktop the build starts
+    # `docker-credential-desktop get`, and that helper can be orphaned still
+    # holding the stderr it inherited. A pipe reaches end of file only when
+    # every holder has closed it, so reading one waited on the orphan and a
+    # run hung after its image was built. With a file the wait is on docker
+    # alone. The build keeps the caller's session: in a new one, Ctrl+C at
+    # the terminal would no longer reach docker.
+    with tempfile.TemporaryFile() as log:
+        try:
+            proc = subprocess.run(
+                argv, stdout=subprocess.DEVNULL, stderr=log, timeout=timeout
+            )
+        except subprocess.TimeoutExpired:
+            by_hand = shlex.join(["docker", "build", "-t", tag, str(model.path)])
+            raise RunnerError(
+                f"{model.name}: building {tag} did not finish in {timeout:g} s. "
+                "A credential helper that never answers stalls a build this way; "
+                "on Docker Desktop, look for a `docker-credential-desktop` process "
+                "and end it. A first build of a large image can also take this "
+                f"long: run `{by_hand}` once by hand, "
+                "and the cached rebuild here takes seconds."
+            ) from None
+        if proc.returncode != 0:
+            log.seek(0)
+            tail = log.read().decode(errors="replace").strip().splitlines()[-20:]
+            raise RunnerError(
+                f"{model.name}: image build failed\n"
+                + "\n".join("    " + line for line in tail)
+            )
     return tag
 
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -301,6 +301,89 @@ def test_missing_daemon_is_reported_as_such(monkeypatch):
         docker_runner.require_docker()
 
 
+def fake_docker(tmp_path, script):
+    """Write `script` as an executable `docker`, so build() runs without a daemon."""
+    import os
+    import shutil
+
+    sh = shutil.which("sh")
+    if os.name != "posix" or sh is None:
+        pytest.skip("the fake docker is a POSIX shell script")
+    docker = tmp_path / "docker"
+    docker.write_text(f"#!{sh}\n{script}\n")
+    docker.chmod(0o755)
+    return str(docker)
+
+
+def test_image_build_returns_when_docker_exits_not_when_its_output_closes(tmp_path):
+    """On Docker Desktop, `docker build` starts `docker-credential-desktop
+    get`, and that helper can be orphaned still holding the stderr it
+    inherited. Reading the build's output through a pipe then waits for an
+    end of file that never comes: `ht run` sat for seven minutes after the
+    image was built. This docker exits 0 at once and leaves such a child."""
+    import os
+    import shlex
+    import signal
+    import threading
+    import time
+
+    from hydroturing.runner import docker_runner
+
+    model = registry.find_model("reference_bucket")
+    pidfile = tmp_path / "helper.pid"
+    docker = fake_docker(tmp_path, f"sleep 30 &\necho $! > {shlex.quote(str(pidfile))}\nexit 0")
+
+    def end_helper():
+        # Once only, so a pid the system has since reused is never signalled.
+        try:
+            pid = int(pidfile.read_text())
+            pidfile.unlink()
+            os.kill(pid, signal.SIGTERM)
+        except (OSError, ValueError):
+            pass
+
+    # A regression blocks until the helper exits. The watchdog ends it after
+    # ten seconds, so the test fails on the assertion rather than hanging.
+    watchdog = threading.Timer(10, end_helper)
+    watchdog.start()
+    started = time.monotonic()
+    try:
+        tag = docker_runner.build(model, docker=docker)
+    finally:
+        elapsed = time.monotonic() - started
+        watchdog.cancel()
+        watchdog.join()
+        end_helper()
+
+    assert tag == docker_runner.image_tag(model)
+    assert elapsed < 5, f"build() returned after {elapsed:.1f} s, waiting on the orphan"
+
+
+def test_image_build_that_never_exits_names_the_image_and_the_credential_helper(tmp_path):
+    """A build can also stall inside docker, waiting on a credential helper
+    that never answers. It ends at the timeout with a reason, not silently."""
+    from hydroturing.runner import docker_runner
+    from hydroturing.runner.base import RunnerError
+
+    model = registry.find_model("reference_bucket")
+    docker = fake_docker(tmp_path, "exec sleep 30")
+    with pytest.raises(RunnerError, match="docker-credential-desktop") as raised:
+        docker_runner.build(model, docker=docker, timeout=0.5)
+    assert docker_runner.image_tag(model) in str(raised.value)
+
+
+def test_failed_image_build_still_reports_the_end_of_its_log(tmp_path):
+    """The build log is no longer read from a pipe; a failed build must
+    still say why it failed."""
+    from hydroturing.runner import docker_runner
+    from hydroturing.runner.base import RunnerError
+
+    model = registry.find_model("reference_bucket")
+    docker = fake_docker(tmp_path, "echo 'step 1/1: pip install failed' >&2\nexit 1")
+    with pytest.raises(RunnerError, match="image build failed\n    step 1/1: pip install failed"):
+        docker_runner.build(model, docker=docker)
+
+
 def test_submitted_model_cannot_request_host_subprocess_access(tmp_path):
     import shutil
 


### PR DESCRIPTION
## Summary

- **`build()`** in `src/hydroturing/runner/docker_runner.py` no longer reads `docker build`'s output through pipes. Its stderr goes to a temporary file, and its stdout, which was never read, goes to `/dev/null`. `subprocess.run` therefore waits on the docker process alone.
  - On Docker Desktop the build starts `docker-credential-desktop get`. That helper can be orphaned (ppid 1) while it still holds the stderr it inherited.
  - A pipe reaches end of file only when every holder has closed it, so `communicate()` waited on the orphan.
  - On 2026-09-11, `ht run --model wflow_sbm --probe mass/antecedent-monotonicity --gate-seeds` sat for about 7 minutes after `docker build --quiet -t hydroturing/wflow_sbm:1.0.4-ht.2` had finished. No container had started and there was no error. `lsof` paired the run's pipe with the orphaned helper, and killing the helper let the run continue at once.
- **Timeout.** `build()` takes `timeout=BUILD_TIMEOUT_S`, set to 1800 s.
  - It covers a build that never exits by itself, for example when docker waits on a helper that never answers. That raises `RunnerError` naming the model, the image tag and the credential helper.
  - The message also says a first build of a heavy image can take that long, and gives the `docker build` command to run once by hand.
  - Why 1800 s: it is twice the 15-minute first build the evaluation skill records, and it ends inside the model workflow's 45-minute job. `run_probe` creates a runner per probe, so a build that stalls every time pays the timeout once per probe; a longer limit would multiply that.
  - The observed hang does not depend on the timeout at all. It came after the build, and `build()` now returns as soon as docker exits.
- **Why not `start_new_session=True`.** It would also free the pipe, but it takes docker out of the terminal's foreground process group, so Ctrl+C would reach only Python.
- **Tests.** Three new tests in `tests/test_harness.py` drive `build()` with a fake `docker` written as a shell script. They skip where there is no POSIX shell.
  1. The script exits 0 and leaves `sleep 30 &` holding stderr. `build()` must return within 5 s. A 10 s watchdog kills the child, so a regression fails instead of hanging.
  2. The script runs `exec sleep 30`. With `timeout=0.5`, `build()` must raise the new error.
  3. The script fails. The error must still carry the tail of its log.

## Verification

- **Before the change:** test 1 failed at 10.0 s, when the watchdog released it. Test 2 failed with `TypeError`, since there was no `timeout` parameter. Test 3 passed. After the change, all three pass.
- **Full suite:** `PYTHONPATH=src PYTHONUTF8=1 HT_ASCII=1 <venv>/bin/python -m pytest -q tests/` gives 336 passed: the 333 on main plus these 3. That run used Python 3.14.3 in a scratch venv with numpy, pandas, PyYAML, jsonschema and pytest. No `sleep` process was left running afterwards.
- **Python 3.12.12:** the Docker runner tests in `test_harness.py` pass, the new ones in under 0.6 s each.
- **`ht validate`:** validation passed, 19 probes, 31 models.
- **Real Docker Desktop on macOS:** `ht verify-adapter --model wflow_sbm` built through the new `build()` (cached) and ran the container. Adapter contract OK, exit 0, 12 s. The orphaning is intermittent, so this run shows only that the real path still works; the fake docker is what reproduces the mechanism.
- **`ruff check`:** the same findings on both files as on main, only at shifted lines.
- **Review:** a separate review pass found nothing blocking. Its smaller points are in this PR: a shorter timeout, a quoted by-hand command, and test cleanup that cannot raise.

## Not changed

- **Kill on timeout.** A timeout kills the docker CLI, which `subprocess.run` does with SIGKILL. Whether the buildx plugin stops with it was not checked, and sending SIGTERM first was not added. Either way, a leftover build no longer blocks the harness.
- **Failed builds between probes.** A failed or timed-out build is not remembered across probes. Remembering it would turn a one-off stall into a failure for the rest of the run.
- **`docker info` and `docker run`.** `require_docker()`'s `docker info` and the `docker run` call still capture through pipes. Neither needs registry credentials in normal use: `docker run` starts an image that was just built locally, and it already has `timeout=probe.max_runtime_s`.

## Related

#39 also adds tests to `tests/test_harness.py`, after main's line 220. These go after line 301, so the hunks do not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
