### PR TITLE
Kill a container that runs past its time budget

### DIFF
--- a/src/hydroturing/runner/docker_runner.py
+++ b/src/hydroturing/runner/docker_runner.py
@@ -118,10 +118,16 @@ def kill_container(docker: str, name: str) -> None:
     """End a container whose `docker run` was cut off.
 
     `docker kill` stops a running container, and --rm then removes it. A
-    container the client created but never got to start is not running, so
-    the kill fails on it and `docker rm -f` removes it instead. If neither
-    finds the container, it has already gone or was never created, and there
-    is nothing left to end.
+    container that is not running, such as one created but never started,
+    fails the kill, and `docker rm -f` removes it instead. A start the client
+    sent before it died holds the container's lock in the daemon, the lock
+    both commands take, so that start either finishes and is killed or is
+    refused. Nothing is retried. A container neither command finds has
+    already gone or was not yet created, and one created afterwards is never
+    started, because `docker run` starts it from the client, which is dead.
+    It takes no CPU, but stays until removed by hand. A command that cannot
+    be run at all is skipped, so the caller's budget error is the one
+    reported.
     """
     for argv in ([docker, "kill", name], [docker, "rm", "-f", name]):
         try:
@@ -129,7 +135,7 @@ def kill_container(docker: str, name: str) -> None:
                 argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                 timeout=KILL_TIMEOUT_S,
             )
-        except subprocess.TimeoutExpired:
+        except (OSError, subprocess.TimeoutExpired):
             continue
         if done.returncode == 0:
             return

--- a/src/hydroturing/runner/docker_runner.py
+++ b/src/hydroturing/runner/docker_runner.py
@@ -12,6 +12,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import uuid
 from pathlib import Path
 
 from hydroturing.runner.base import Runner, RunnerError
@@ -25,9 +26,21 @@ IMAGE_PREFIX = "hydroturing"
 # build that never exits, not a budget for a slow one.
 BUILD_TIMEOUT_S = 1800
 
+# How long `docker kill`, and then `docker rm -f`, may take to end a container
+# that ran past its budget. Either normally returns within seconds; the limit
+# is for a daemon that has stopped answering, so the budget error still
+# reaches the caller instead of a second hang.
+KILL_TIMEOUT_S = 30
+
 
 def image_tag(model: ModelManifest) -> str:
     return f"{IMAGE_PREFIX}/{model.name}:{model.version}"
+
+
+def container_name(model: ModelManifest) -> str:
+    """A name unique to one run, so two sessions running the same model on
+    one daemon never collide."""
+    return f"{IMAGE_PREFIX}-{model.name}-{uuid.uuid4().hex}"
 
 
 def require_docker() -> str:
@@ -101,6 +114,27 @@ def build(
     return tag
 
 
+def kill_container(docker: str, name: str) -> None:
+    """End a container whose `docker run` was cut off.
+
+    `docker kill` stops a running container, and --rm then removes it. A
+    container the client created but never got to start is not running, so
+    the kill fails on it and `docker rm -f` removes it instead. If neither
+    finds the container, it has already gone or was never created, and there
+    is nothing left to end.
+    """
+    for argv in ([docker, "kill", name], [docker, "rm", "-f", name]):
+        try:
+            done = subprocess.run(
+                argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                timeout=KILL_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+        if done.returncode == 0:
+            return
+
+
 class DockerRunner(Runner):
     name = "docker"
 
@@ -115,14 +149,16 @@ class DockerRunner(Runner):
         return ["--user", f"{os.getuid()}:{os.getgid()}"]
 
     @staticmethod
-    def command(docker: str, tag: str, model: ModelManifest, io_dir: Path) -> list[str]:
+    def command(docker: str, tag: str, model: ModelManifest, io_dir: Path, name: str) -> list[str]:
         """Build the run command.
 
         Isolation is part of the benchmark, not an operational detail, so this
         is asserted by the test suite rather than trusted. Inputs and the
         request are mounted read-only; only the output directory is writable.
         The image's own working directory is preserved so a relative entrypoint
-        resolves exactly as it did when the image was built.
+        resolves exactly as it did when the image was built. The container
+        takes the caller's `name`, so a run cut off at its time budget can be
+        found and killed.
         """
         resources = model.resources or {}
         request_path = (io_dir / "request.json").resolve()
@@ -142,6 +178,7 @@ class DockerRunner(Runner):
         # wants a cache directory has one that vanishes with the container.
         return [
             docker, "run", "--rm",
+            "--name", name,
             *DockerRunner.user_flags(),
             "--env", "HOME=/tmp",
             "--network", "none",
@@ -164,12 +201,19 @@ class DockerRunner(Runner):
         if self._tag is None:
             self._tag = build(model, docker=docker)
         tag = self._tag
-        argv = self.command(docker, tag, model, io_dir)
+        name = container_name(model)
+        argv = self.command(docker, tag, model, io_dir, name)
         try:
             proc = subprocess.run(
                 argv, capture_output=True, text=True, timeout=probe.max_runtime_s
             )
         except subprocess.TimeoutExpired:
+            # The timeout ends the docker client, not the container, which
+            # runs on in the daemon until it finishes by itself; --rm removes
+            # it only then. On a shared host that load pushes the next cases
+            # over their budgets too, so the container is killed by name
+            # before the budget error is raised.
+            kill_container(docker, name)
             raise RunnerError(
                 f"{model.name}: container exceeded the time budget for {probe.id}"
             ) from None

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -233,7 +233,7 @@ def test_container_runs_with_hardened_read_only_inputs(tmp_path):
     from hydroturing.runner.docker_runner import DockerRunner
 
     model = registry.find_model("reference_bucket")
-    argv = DockerRunner.command("docker", "img:1", model, tmp_path)
+    argv = DockerRunner.command("docker", "img:1", model, tmp_path, "hydroturing-test")
 
     assert argv[:3] == ["docker", "run", "--rm"]
     assert "--network" in argv and argv[argv.index("--network") + 1] == "none"
@@ -276,11 +276,11 @@ def test_cpu_request_is_capped_at_the_host(monkeypatch, tmp_path):
 
     model = replace(registry.find_model("reference_bucket"), resources={"cpu": 8, "memory_gb": 8})
     monkeypatch.setattr(docker_runner.os, "cpu_count", lambda: 4)
-    argv = DockerRunner.command("docker", "img:1", model, tmp_path)
+    argv = DockerRunner.command("docker", "img:1", model, tmp_path, "hydroturing-test")
     assert argv[argv.index("--cpus") + 1] == "4"
 
     monkeypatch.setattr(docker_runner.os, "cpu_count", lambda: 16)
-    argv = DockerRunner.command("docker", "img:1", model, tmp_path)
+    argv = DockerRunner.command("docker", "img:1", model, tmp_path, "hydroturing-test")
     assert argv[argv.index("--cpus") + 1] == "8"
 
 
@@ -382,6 +382,43 @@ def test_failed_image_build_still_reports_the_end_of_its_log(tmp_path):
     docker = fake_docker(tmp_path, "echo 'step 1/1: pip install failed' >&2\nexit 1")
     with pytest.raises(RunnerError, match="image build failed\n    step 1/1: pip install failed"):
         docker_runner.build(model, docker=docker)
+
+
+@pytest.mark.parametrize("kill_status", [0, 1], ids=["killed", "created-not-started"])
+def test_container_past_its_time_budget_is_killed_not_left_running(monkeypatch, tmp_path, kill_status):
+    """The timeout ends the docker client, not the container: after
+    extreme-rain timed out for google_flood_forecast, its container was still
+    running five minutes later and taking CPU from the cases behind it. A
+    timed-out run kills the container by the name it ran under, and removes
+    it by force when the kill fails, as on one created but never started."""
+    import shlex
+
+    from hydroturing.runner import docker_runner
+    from hydroturing.runner.base import RunnerError
+
+    calls = tmp_path / "calls"
+    calls.mkdir()
+    log = shlex.quote(str(calls))
+    docker = fake_docker(tmp_path, f"""case "$1" in
+  run) printf '%s\\n' "$@" > {log}/run; exec sleep 30 ;;
+  kill) printf '%s\\n' "$@" > {log}/kill; exit {kill_status} ;;
+  rm) printf '%s\\n' "$@" > {log}/rm ;;
+esac""")
+    monkeypatch.setattr(docker_runner, "require_docker", lambda: docker)
+
+    model = registry.find_model("reference_bucket")
+    probe = replace(registry.find_probe("mass/catchment-closure"), max_runtime_s=1.0)
+    with pytest.raises(RunnerError, match=f"{model.name}: container exceeded the time budget for {probe.id}"):
+        docker_runner.DockerRunner().invoke(model, probe, tmp_path, tmp_path / "request.json")
+
+    run = (calls / "run").read_text().splitlines()
+    name = run[run.index("--name") + 1]
+    assert name.startswith(f"hydroturing-{model.name}-")
+    assert (calls / "kill").read_text().splitlines() == ["kill", name]
+    if kill_status == 0:
+        assert not (calls / "rm").exists()
+    else:
+        assert (calls / "rm").read_text().splitlines() == ["rm", "-f", name]
 
 
 def test_submitted_model_cannot_request_host_subprocess_access(tmp_path):

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -407,7 +407,9 @@ esac""")
     monkeypatch.setattr(docker_runner, "require_docker", lambda: docker)
 
     model = registry.find_model("reference_bucket")
-    probe = replace(registry.find_probe("mass/catchment-closure"), max_runtime_s=1.0)
+    # The fake must start and record its arguments inside the budget, so the
+    # budget leaves a loaded CI runner room for that and nothing more.
+    probe = replace(registry.find_probe("mass/catchment-closure"), max_runtime_s=2.0)
     with pytest.raises(RunnerError, match=f"{model.name}: container exceeded the time budget for {probe.id}"):
         docker_runner.DockerRunner().invoke(model, probe, tmp_path, tmp_path / "request.json")
 


### PR DESCRIPTION
## Problem

`DockerRunner.invoke` runs `docker run --rm ...` through `subprocess.run(..., timeout=probe.max_runtime_s)`. On `TimeoutExpired`, subprocess kills the `docker` CLI client, but the container keeps running in the daemon until it finishes by itself, because `--rm` removes it only on exit. On 2026-09-11, after `mass/extreme-rain` (300 s budget) timed out for `google_flood_forecast`, its container was still running five minutes later. On a shared host that load pushes the next cases over their budgets too.

## Change

- `container_name(model)` returns `hydroturing-<model>-<uuid4 hex>`, so every run has a name known before the container exists.
- `DockerRunner.command(docker, tag, model, io_dir, name)` adds `--name <name>` right after `--rm`. The isolation flags are unchanged, and the argv still starts with `docker run --rm`.
- `kill_container(docker, name)` runs `docker kill <name>`. If that fails, as it does on a container that was created but never started, it runs `docker rm -f <name>`.
  - Each command has a 30 s limit.
  - If a command cannot be started at all (`OSError`), it is skipped, so the budget error is always the error raised.
- On `TimeoutExpired`, `invoke` calls `kill_container` and then raises the same `RunnerError("<model>: container exceeded the time budget for <probe>")` as before.

Only the timeout path changes. The client can also die in other ways (Ctrl+C, the harness process being killed), and those behave as before.

## Review

**Copilot, inline on `docker_runner.py:126`.** The comment says single-shot cleanup can race a `docker run` still in flight and leave the container running. The cleanup can leave a container behind, but never a running one. The cleanup is not retried, and the docstring now explains why. Sources are Docker 28.5.2, the Docker Desktop engine here:

- **A container created after the cleanup never starts.** `docker run` creates the container, then starts it with a second request from the client ([cli run.go L145](https://github.com/docker/cli/blob/v28.5.2/cli/command/container/run.go#L145), [L205](https://github.com/docker/cli/blob/v28.5.2/cli/command/container/run.go#L205)). That client is already dead when the cleanup runs. A container created after both commands found nothing therefore stays in the Created state. It uses no CPU, but it has to be removed by hand.
- **A start already sent cannot slip past the cleanup.** It holds the container's lock from its removal check through `SetRunning` ([start.go L88–L95](https://github.com/moby/moby/blob/v28.5.2/daemon/start.go#L88-L95), [L251](https://github.com/moby/moby/blob/v28.5.2/daemon/start.go#L251)). `docker kill` checks whether the container is running under that same lock ([kill.go L162](https://github.com/moby/moby/blob/v28.5.2/daemon/kill.go#L162), [state.go L242](https://github.com/moby/moby/blob/v28.5.2/container/state.go#L242)). `docker rm -f` marks the container for removal under it too ([delete.go L40](https://github.com/moby/moby/blob/v28.5.2/daemon/delete.go#L40), [state.go L381](https://github.com/moby/moby/blob/v28.5.2/container/state.go#L381)). So the start either finishes and the container is killed, or the start fails because the container is marked for removal or already gone.
- **A retry would buy little.** It could only catch the never-started container. It would also add a wait to every timeout where neither command finds the container.

**Separate pre-PR code review.** It raised three low-severity notes, all fixed in cdeb0d7:

- The docstring claimed nothing could be left behind.
- An `OSError` from starting `docker kill` would have replaced the budget error.
- The new test's 1 s budget was thin for the fake docker to start. It is now 2 s.

## Verification

- `ht validate`: `validation passed: 20 probe(s), 32 model(s), suite 0.1.0`
- `pytest`: 369 passed
- New test `test_container_past_its_time_budget_is_killed_not_left_running` in `tests/test_harness.py`. It uses a fake docker, written with the existing `fake_docker` helper, that records `run`, `kill` and `rm`. It has two cases: the kill succeeds, or the kill fails and `rm -f` follows. With the previous runner the test fails (`'--name' is not in list`). With only the `kill_container` call removed it also fails, because no kill is recorded.
- Live check using the existing `hydroturing/google_flood_forecast:0.1.0-828dfc5` image on `mass/catchment-closure` with `max_runtime_s=4`. Only containers whose `/io/output` mount is that run's own directory are counted.

  | daemon | code | `RunnerError` after | this run's container 2 / 5 / 10 s later |
  |---|---|---|---|
  | Docker Desktop 28.5.2 (16 CPUs) | origin/main | 4.1 s | running / running / running (removed by hand) |
  | Docker Desktop 28.5.2 (16 CPUs) | this branch | 4.3 s | none / none / none |
  | Colima 29.5.2 (10 CPUs, busy) | origin/main | 4.1 s | running / running / running (removed by hand) |
  | Colima 29.5.2 (10 CPUs, busy) | this branch | 5.3 s | none / none / none |

  The extra time on this branch is the `docker kill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
