### PR TITLE
Report a contract check the model cannot be put to as N/A, not FAIL

### DIFF
--- a/.claude/skills/hydroturing-evaluate-model/SKILL.md
+++ b/.claude/skills/hydroturing-evaluate-model/SKILL.md
@@ -129,6 +129,9 @@ places where following it took judgement.
 - `ht validate`, `ht gate`, `ht list`, `pytest -q` must all be green before a
   push; `ht run` exit 1 is a scientific FAIL, or N/A for a model no probe
   could score (both fine), exit 2 is a harness ERROR (not fine).
+  `ht verify-adapter` uses the same codes: 1 when the check is N/A because
+  the model cannot consume the named probe, or any probe, so the adapter was
+  not run; 2 when the adapter broke the contract. A crash exits 2 from either.
 - Every probe must pass four physical models (`reference_bucket`,
   `flex_lumped`, `flex_topo`, `sacsma_snow17`) and fail its named broken one; a probe PR is
   gated on the physical models first. The seven merged probes and what each

--- a/.claude/skills/hydroturing-evaluate-model/references/environment.md
+++ b/.claude/skills/hydroturing-evaluate-model/references/environment.md
@@ -35,7 +35,8 @@ in the message closes the submission issue on push.
 - `model` workflow: manual only since 2026-09-05,
   `gh workflow run model --ref main -f model=<name>` (blank = every model); 45-minute limit;
   builds the image without secrets, `ht verify-adapter`, then `ht run` with
-  fresh seeds; exit 1 (FAIL) is green, exit 2 (ERROR) is red; scorecard in
+  fresh seeds; exit 1 is green (a FAIL or N/A from `run`, an N/A from
+  `verify-adapter`) and exit 2 (an ERROR, or any crash) is red; scorecard in
   the log and `results/` as an artifact. δHBV on the full record took ~10
   minutes; Google on 30-day windows could not finish within 45 minutes on
   4 cores before the CPU cap fix and has not been re-run there since.

--- a/.github/workflows/model-eval.yml
+++ b/.github/workflows/model-eval.yml
@@ -56,11 +56,24 @@ jobs:
       - name: Verify the adapter contract
         if: steps.select.outputs.models != ''
         run: |
+          status=0
           for model in ${{ steps.select.outputs.models }}; do
             echo "::group::verify $model"
-            ht verify-adapter --model "$model"
+            if ht verify-adapter --model "$model"; then
+              code=0
+            else
+              code=$?
+            fi
             echo "::endgroup::"
+            # Exit 1 is a check that was N/A: no probe the model can consume,
+            # so its adapter was never run, and `ht run` will say the same.
+            # Exit 2 is an adapter that broke the contract, or the harness
+            # failing, and must make the workflow fail.
+            if [ "$code" -ne 0 ] && [ "$code" -ne 1 ]; then
+              status=1
+            fi
           done
+          exit "$status"
 
       - name: Evaluate
         if: steps.select.outputs.models != ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,14 @@ ht run --model <model-name>              # the actual evaluation
 
 `verify-adapter` runs a single seed, on the same window the evaluation will
 use, and checks the shape of what came back. Get that green before looking
-at any residual. Both commands take `--csv models/result.csv` to append what
+at any residual. Without `--probe` it checks the closure probe, or the first
+probe the model can consume when it cannot consume that one: a step it does
+not declare, a forcing the probe does not generate, or a window that drops a
+stretch the probe scores makes a probe N/A (INCOMPATIBLE) for the model.
+When that is true of the probe named with `--probe`, or of every probe, the
+adapter is not run and the command exits 1, as `ht run` does for a model no
+probe could score. Exit 2 means the adapter broke the contract or the
+harness failed. Both commands take `--csv models/result.csv` to append what
 they found to the archive, and `--window DAYS|full` to override the
 manifest.
 

--- a/docs/adapting-a-model.md
+++ b/docs/adapting-a-model.md
@@ -79,11 +79,20 @@ The entrypoint stays empty; `model.yaml` supplies the argv.
 ht verify-adapter --model my-model
 ```
 
-This always invokes the adapter, even when the model cannot emit enough
-variables for the selected scientific probe. It asks for every output declared
-in `model.yaml` and checks the row count, exact time axis, declared columns,
+This invokes the adapter even when the model cannot emit enough variables for
+the selected scientific probe. It asks for every output declared in
+`model.yaml` and checks the row count, exact time axis, declared columns,
 finite values and output-size limit. Get it green first. A residual computed
 from a malformed table tells you nothing.
+
+It runs on the closure probe, or on the first probe your model can consume
+when it cannot consume that one: a model driven by net radiation is checked
+on an energy probe, because the closure probe generates none. A probe the
+model cannot consume, at its step, with its forcing or on its window, is N/A
+(INCOMPATIBLE) for it. When that is true of the probe named with `--probe`,
+or of every probe, the adapter is not run and the command exits 1, as
+`ht run` does for a model no probe could score. Exit 0 is a contract that
+holds, exit 2 an adapter or harness failure.
 
 ## The evaluation window
 

--- a/src/hydroturing/cli.py
+++ b/src/hydroturing/cli.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import traceback
 from dataclasses import replace
 import tempfile
 from pathlib import Path
@@ -20,6 +21,7 @@ from pathlib import Path
 from hydroturing import SUITE_VERSION, __version__
 from hydroturing import registry
 from hydroturing.harness import (
+    IncompatibleError,
     resolve_window_days,
     run_model,
     run_probe,
@@ -41,7 +43,7 @@ from hydroturing.scaffold import (
     scaffold_probe,
     write_draft,
 )
-from hydroturing.scoring import ERROR, FAIL, PASS
+from hydroturing.scoring import ERROR, FAIL, INCOMPATIBLE, NOT_SCORED, PASS
 from hydroturing.seeds import gate_seeds
 from hydroturing.spec import (
     FULL_WINDOW,
@@ -211,33 +213,62 @@ def cmd_validate(args) -> int:
 
 
 def cmd_verify_adapter(args) -> int:
-    """Smoke test before any physics: does the adapter obey the contract?"""
+    """Smoke test before any physics: does the adapter obey the contract?
+
+    Exits as `ht run` does. 0: the contract holds. 1: the check is N/A,
+    because the model cannot consume the probe and the adapter was never
+    run. 2: the adapter or the harness failed.
+    """
     model = registry.find_model(args.model)
     probes = _all_probes(args)
     if not probes:
         print("no probes available to smoke test against")
-        return 1
+        return 2
     roots = _probe_roots(args)
     if args.probe:
-        probe = registry.find_probe(args.probe, roots)
+        candidates = [registry.find_probe(args.probe, roots)]
     else:
         # The closure probe is the reference implementation and the natural
-        # smoke test; fall back to the first probe the model's step fits.
-        ordered = sorted(probes, key=lambda p: (p.id != "mass/catchment-closure", p.id))
-        probe = next(
-            (p for p in ordered if all(model.supports_timestep(t) for t in p.timesteps)),
-            ordered[0],
-        )
+        # smoke test. A model that cannot consume it, at its step, with its
+        # forcing or on its window, is checked on the first probe it can
+        # consume instead: one it cannot is N/A for it and asks the adapter
+        # nothing.
+        candidates = sorted(probes, key=lambda p: (p.id != "mass/catchment-closure", p.id))
 
-    seed = gate_seeds(probe.id, 1)[0]
-    try:
-        workdir = Path(args.workdir) if args.workdir else None
-        result = verify_adapter_contract(model, probe, seed, workdir=workdir, window=args.window)
-    except Exception as exc:  # report a clean smoke-test failure, never a traceback
-        print(f"{prefix(False)}adapter contract FAILED for {model.name}:\n  {exc}")
+    workdir = Path(args.workdir) if args.workdir else None
+    result = None
+    refused = []
+    for probe in candidates:
+        seed = gate_seeds(probe.id, 1)[0]
+        try:
+            result = verify_adapter_contract(model, probe, seed, workdir=workdir, window=args.window)
+            break
+        except IncompatibleError as exc:
+            # Refused before the adapter is invoked, so trying the next probe
+            # costs a generated case, not an adapter run.
+            refused.append((probe, seed, exc))
+        except Exception as exc:  # report a clean smoke-test failure, never a traceback
+            # A bare assert has no message, and an empty detail would read as nothing wrong.
+            message = str(exc) or type(exc).__name__
+            print(f"{prefix(False)}adapter contract FAILED for {model.name} on {probe.id}:\n  {message}")
+            if args.csv:
+                _archive_contract(args.csv, model, probe, seed, error=message)
+            return 2
+
+    if result is None:
+        # The first refusal is the probe that was named, or the closure probe
+        # when the choice was left to the harness and no probe would do.
+        probe, seed, exc = refused[0]
+        subject, reasons = (probe.id, str(exc)) if args.probe else ("every probe", f"{probe.id}: {exc}")
+        print(
+            f"{prefix(None)}adapter contract not checked for {model.name}: {subject} is "
+            f"{NOT_SCORED} ({INCOMPATIBLE}) for this model, so the adapter was not run:\n"
+            f"  {reasons}"
+        )
         if args.csv:
-            _archive_contract(args.csv, model, probe, seed, error=str(exc))
+            _archive_contract(args.csv, model, probe, seed, incompatible=exc.issues)
         return 1
+
     if args.csv:
         path = _archive_contract(args.csv, model, probe, seed, result=result)
         print(f"appended 1 row to {path}")
@@ -255,10 +286,10 @@ def cmd_verify_adapter(args) -> int:
     return 0
 
 
-def _archive_contract(path, model, probe, seed, *, result=None, error=None) -> Path:
+def _archive_contract(path, model, probe, seed, *, result=None, error=None, incompatible=None) -> Path:
     row = contract_row(
         model.name, model.version, SUITE_VERSION, model.runner, probe.id, seed,
-        result=result, error=error,
+        result=result, error=error, incompatible=incompatible,
     )
     return append_csv_rows([row], path)
 
@@ -440,6 +471,11 @@ def main(argv: list[str] | None = None) -> int:
         return args.fn(args)
     except (KeyError, SpecError) as exc:
         print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except Exception:  # noqa: BLE001 - a crash nothing anticipated is a harness ERROR too
+        # Python exits 1 on an uncaught exception, and CI accepts exit 1 as a
+        # FAIL or an N/A. A crash is neither, so it keeps its traceback and exits 2.
+        traceback.print_exc()
         return 2
 
 

--- a/src/hydroturing/harness.py
+++ b/src/hydroturing/harness.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from hydroturing import SUITE_VERSION, criteria as criteria_mod
 from hydroturing.criteria.base import CriterionResult
-from hydroturing.protocol import Case, ProtocolError, RunResult
+from hydroturing.protocol import Case, RunResult
 from hydroturing.runner import get_runner
 from hydroturing.scoring import (
     FAIL,
@@ -42,6 +42,18 @@ WINDOW_DRIVER = "pr"
 
 class WindowError(ValueError):
     """A window cannot be cut from this case without breaking the probe."""
+
+
+class IncompatibleError(Exception):
+    """The model cannot consume this probe, which is N/A (INCOMPATIBLE) for it.
+
+    Raised before the adapter runs, so that a check that never put the probe
+    to the model is not mistaken for an adapter that broke the contract.
+    """
+
+    def __init__(self, issues: list[str]):
+        super().__init__("; ".join(issues))
+        self.issues = list(issues)
 
 
 def resolve_window_days(
@@ -369,6 +381,12 @@ def verify_adapter_contract(
     probe needs variables the model does not produce. That limitation belongs
     to the probe's later N/A (INCOMPLETE), not to this smoke test.
 
+    A probe the model cannot consume is another matter: a step it does not
+    declare, a forcing it needs and the probe does not generate, a window
+    that drops a stretch the probe scores. There is nothing to run the
+    adapter on, so IncompatibleError is raised before it is invoked, on the
+    same grounds that make `run_probe` call the probe N/A (INCOMPATIBLE).
+
     The case is cut to the model's evaluation window, as it will be in the
     real run, so a model that only fits its time budget on the window is
     smoke-tested under the same conditions it is scored under.
@@ -378,11 +396,15 @@ def verify_adapter_contract(
     case = build_case(probe, seed, select_variants(model, probe)[0])
     issues = compatibility_issues(model, probe, case, check_perturbation=False)
     if issues:
-        raise ProtocolError("; ".join(issues))
+        raise IncompatibleError(issues)
 
     days = resolve_window_days(model, probe, window)
     if days is not None:
-        case = window_case(case, select_window(case, probe, days))
+        bounds = select_window(case, probe, days)
+        try:
+            case = window_case(case, bounds)
+        except WindowError as exc:
+            raise IncompatibleError([str(exc)]) from exc
 
     smoke_probe = replace(
         probe,

--- a/src/hydroturing/report.py
+++ b/src/hydroturing/report.py
@@ -17,7 +17,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from hydroturing.scoring import NOT_SCORED, PASS, ModelReport, ProbeOutcome
+from hydroturing.scoring import (
+    ERROR,
+    FAIL,
+    INCOMPATIBLE,
+    NOT_SCORED,
+    OK,
+    PASS,
+    ModelReport,
+    ProbeOutcome,
+)
 
 PASS_MARK, FAIL_MARK, NOT_SCORED_MARK = "\u2705", "\u274c", "\u2796"
 # Same width as each other, so columns line up whichever set is in use.
@@ -263,6 +272,7 @@ def contract_row(
     *,
     result=None,
     error: str | None = None,
+    incompatible: list[str] | None = None,
     run_date: str | None = None,
 ) -> dict[str, str]:
     """The adapter contract check as one archive row.
@@ -270,16 +280,22 @@ def contract_row(
     For a model that reports only discharge this is the only line saying
     that it was actually built and run on a budget probe: that probe is
     N/A (INCOMPLETE) before the container is ever started.
+
+    A check on a probe the model cannot consume is N/A (INCOMPATIBLE), not
+    an ERROR: the adapter was never invoked, and the row says why.
     """
     run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
     if error is not None:
-        verdict, reason, window, detail = "FAIL", "ERROR", "not run", error.splitlines()[0][:160]
+        verdict, reason, window, detail = FAIL, ERROR, "not run", error.splitlines()[0][:160]
+    elif incompatible:
+        verdict, reason, window = NOT_SCORED, INCOMPATIBLE, "not run"
+        detail = "; ".join(incompatible)[:400]
     else:
         case = result.case
         window = (
             f"{case.window['days']}-day flood event" if case.window else "full record"
         )
-        verdict, reason = "PASS", "OK"
+        verdict, reason = PASS, OK
         detail = (
             f"adapter contract OK: {len(result.table)} rows in {result.wall_seconds:.1f}s, "
             f"columns {', '.join(c for c in result.table.columns if c != 'time')}"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -15,6 +15,7 @@ import pytest
 
 from hydroturing import registry
 from hydroturing.harness import (
+    IncompatibleError,
     build_case,
     run_model,
     run_probe,
@@ -237,12 +238,48 @@ def test_run_exits_2_when_an_error_sits_beside_unscored_probes(monkeypatch):
     assert cli.main(["run", "--model", "reference_bucket", "--probe", "mass/catchment-closure"]) == 2
 
 
+def test_a_command_that_crashes_exits_2(monkeypatch, capsys):
+    """Python exits 1 on an uncaught exception, and CI accepts exit 1 as a
+    FAIL or an N/A. A crash nothing anticipated, such as a model.yaml that is
+    not YAML, is the harness failing and must exit 2 with its traceback."""
+    import yaml
+
+    from hydroturing import cli
+
+    def unreadable(name):
+        raise yaml.YAMLError(f"{name}/model.yaml is not YAML")
+
+    monkeypatch.setattr(cli.registry, "find_model", unreadable)
+    assert cli.main(["verify-adapter", "--model", "reference_bucket"]) == 2
+    assert cli.main(["run", "--model", "reference_bucket"]) == 2
+    assert "reference_bucket/model.yaml is not YAML" in capsys.readouterr().err
+
+
 def test_adapter_verification_runs_an_incomplete_model(probe):
     """A probe that is N/A (INCOMPLETE) must not skip the contract smoke test."""
     model = registry.find_model("reference_streamflow_only")
     result = verify_adapter_contract(model, probe, gate_seeds(probe.id, 1)[0])
     assert len(result.table) == result.case.n_steps
     assert {"time", "mrro", "dis"} <= set(result.table.columns)
+
+
+def test_adapter_verification_does_not_run_a_probe_the_model_cannot_consume(probe, monkeypatch):
+    """A model needing a forcing the probe does not generate cannot be put to
+    it. That is the probe's N/A (INCOMPATIBLE), decided before the adapter is
+    invoked, and must not surface as the adapter breaking the contract."""
+    from hydroturing import harness
+
+    def no_runner(model):
+        raise AssertionError(f"the adapter of {model.name} was run")
+
+    monkeypatch.setattr(harness, "get_runner", no_runner)
+    model = replace(
+        registry.find_model("reference_bucket"),
+        needs_forcing=("pr", "unavailable_driver"),
+    )
+    with pytest.raises(IncompatibleError) as refused:
+        verify_adapter_contract(model, probe, gate_seeds(probe.id, 1)[0])
+    assert refused.value.issues == ["forcing does not provide unavailable_driver"]
 
 
 def test_all_seeds_must_pass(probe):

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -17,6 +17,7 @@ import pytest
 
 from hydroturing import registry
 from hydroturing.harness import (
+    IncompatibleError,
     WindowBounds,
     WindowError,
     build_case,
@@ -283,3 +284,105 @@ def test_contract_check_can_be_archived(probe, tmp_path):
     assert row["window"] == "full record"
     assert row["detail"].startswith("adapter contract OK: 4015 rows")
     assert row["seeds"] == str(gate_seeds(probe.id, 1)[0])
+
+
+def test_verify_adapter_is_not_run_on_a_window_that_drops_a_scored_stretch(probe, monkeypatch):
+    """The window rule is the one `run_probe` applies: a window that cuts away
+    a stretch the probe labels makes the probe N/A (INCOMPATIBLE), so the
+    contract is not checked on it either."""
+    from hydroturing import harness
+
+    real_build_case = harness.build_case
+
+    def labelled(probe, seed, variant=None):
+        case = real_build_case(probe, seed, variant)
+        # A labelled stretch at each end of the record: no 30-day window keeps both.
+        labels = np.array(["ordinary"] * case.n_steps, dtype=object)
+        labels[case.spinup_steps], labels[-1] = "first", "last"
+        return replace(case, forcing=case.forcing.assign(_regime=labels))
+
+    monkeypatch.setattr(harness, "build_case", labelled)
+    with pytest.raises(IncompatibleError, match="_regime"):
+        verify_adapter_contract(_submitted(), probe, gate_seeds(probe.id, 1)[0])
+
+
+def test_contract_check_runs_on_a_probe_the_model_can_consume(tmp_path):
+    """Left to choose, the check picks a probe the model can consume. A model
+    driven by net radiation cannot be put to the closure probe, which
+    generates none, and is checked on one that does rather than failing a
+    contract it was never asked to honour."""
+    from hydroturing.cli import main
+
+    archive = tmp_path / "result.csv"
+    assert main(["verify-adapter", "--model", "reference_coupled", "--csv", str(archive)]) == 0
+    with open(archive, newline="") as fh:
+        (row,) = list(csv.DictReader(fh))
+    chosen = row["probe"].removesuffix(" (adapter contract)")
+    assert chosen != "mass/catchment-closure"
+    assert (row["verdict"], row["reason"]) == ("PASS", "OK")
+    assert row["seeds"] == str(gate_seeds(chosen, 1)[0])
+
+
+def test_contract_check_on_a_probe_the_model_cannot_consume_is_not_scored(probe, tmp_path, capsys):
+    """Named a probe it cannot consume, the check says so and archives N/A
+    (INCOMPATIBLE) rather than FAIL (ERROR). It exits 1, as `ht run` does for
+    a model no probe could score, because CI reads only exit 2 as broken."""
+    from hydroturing.cli import main
+
+    archive = tmp_path / "result.csv"
+    assert main([
+        "verify-adapter", "--model", "reference_coupled",
+        "--probe", probe.id, "--csv", str(archive),
+    ]) == 1
+    out = capsys.readouterr().out
+    assert "mass/catchment-closure is N/A (INCOMPATIBLE)" in out
+    assert "forcing does not provide rn" in out
+    with open(archive, newline="") as fh:
+        (row,) = list(csv.DictReader(fh))
+    assert row["probe"] == "mass/catchment-closure (adapter contract)"
+    assert (row["verdict"], row["reason"], row["window"]) == ("N/A", "INCOMPATIBLE", "not run")
+    assert row["detail"] == "forcing does not provide rn"
+    assert row["seeds"] == str(gate_seeds(probe.id, 1)[0])
+
+
+def test_contract_check_with_no_probe_the_model_can_consume_is_not_scored(capsys, monkeypatch):
+    """With no probe it can consume there is nothing to run the adapter on.
+    That is N/A too, and names the closure probe's reasons."""
+    from hydroturing.cli import main
+
+    real_find_model = registry.find_model
+    unfed = replace(
+        real_find_model("reference_bucket"),
+        name="unfed_model",
+        needs_forcing=("pr", "unavailable_driver"),
+    )
+    monkeypatch.setattr(
+        registry, "find_model", lambda name: unfed if name == "unfed_model" else real_find_model(name)
+    )
+    assert main(["verify-adapter", "--model", "unfed_model"]) == 1
+    out = capsys.readouterr().out
+    assert "every probe is N/A (INCOMPATIBLE)" in out
+    assert "mass/catchment-closure: forcing does not provide unavailable_driver" in out
+
+
+def test_a_broken_contract_exits_2(probe, tmp_path, capsys, monkeypatch):
+    """An adapter that breaks the contract is an ERROR and exits 2, as in
+    `ht run`, so CI can tell it from a check that was N/A. A failure with no
+    message still says what failed."""
+    from hydroturing import harness
+    from hydroturing.cli import main
+
+    class Broken:
+        def run(self, model, probe, case, io_dir):
+            raise AssertionError()
+
+    monkeypatch.setattr(harness, "get_runner", lambda model: Broken())
+    archive = tmp_path / "result.csv"
+    assert main([
+        "verify-adapter", "--model", "reference_bucket",
+        "--probe", probe.id, "--csv", str(archive),
+    ]) == 2
+    assert "adapter contract FAILED for reference_bucket on mass/catchment-closure" in capsys.readouterr().out
+    with open(archive, newline="") as fh:
+        (row,) = list(csv.DictReader(fh))
+    assert (row["verdict"], row["reason"], row["detail"]) == ("FAIL", "ERROR", "AssertionError")


### PR DESCRIPTION
Stacked on #44: the base is `fix/incomplete-is-not-a-fail`, so the diff here is only this change. Retarget to `main` once #44 merges, if GitHub does not do it on its own.

## Why

Review of #44 found a problem that predates it. `ht verify-adapter` chose its probe by timestep alone. `verify_adapter_contract` then raised `ProtocolError` for any probe whose forcing the model could not consume, and `cmd_verify_adapter` reported that as a broken contract: `adapter contract FAILED`, a `FAIL,ERROR` archive row, exit 1. Under #44 such a probe is N/A (INCOMPATIBLE) for the model, not a failure.

On #44's head, six reference models that need net radiation fail this way on `mass/catchment-closure`, which generates no `rn`:

```
reference_constant_lambda: exit 1 | adapter contract FAILED for reference_constant_lambda:   forcing does not provide rn
reference_coupled:         exit 1 | adapter contract FAILED for reference_coupled:   forcing does not provide rn
reference_energy_leak, reference_ground_dodge, reference_sublimation_blind, reference_two_head: the same
```

The verify step in `.github/workflows/model-eval.yml` is unguarded, so `gh workflow run model` with a blank model list went red on the first of them, for adapters that were never run.

## What changes

- **Automatic choice.** It still starts at the closure probe, then tries the other probes in id order and moves past any the model cannot consume. That uses the same test that decides N/A in `ht run`: the step, the forcing, and a window that would cut away a stretch the probe scores. `verify_adapter_contract` raises a new `IncompatibleError` for those before the adapter is invoked, and turns a `WindowError` into one, as `run_probe` does.
- **A probe the model cannot consume.** This covers a probe named with `--probe`, or the case where no probe at all can be consumed. The command says so plainly and archives `N/A,INCOMPATIBLE,not run`:
  ```
  adapter contract not checked for reference_coupled: mass/catchment-closure is N/A (INCOMPATIBLE) for this model, so the adapter was not run:
    forcing does not provide rn
  ```
  ```
  2026-09-11,reference_coupled,1.1.0,0.1.0,subprocess,mass/catchment-closure (adapter contract),N/A,INCOMPATIBLE,not run,598896396,forcing does not provide rn
  ```
- **Exit codes now match `ht run`** (the maintainer's call): 0 the contract holds, 1 N/A, 2 the adapter or harness failed.
  - **This is a behaviour change:** a broken contract used to exit 1 and now exits 2. So does the "no probes available" case.
  - The verify step in `model-eval.yml` now tolerates exit 1 the way Evaluate already did. It also verifies every model before failing, instead of stopping at the first.
- **Any crash exits 2** (found in review). `main()` turned only `KeyError` and `SpecError` into exit 2. Any other uncaught exception took Python's default exit 1, which the verify step now accepts and Evaluate already accepted, so a `model.yaml` that is not YAML would have passed green. It now prints the traceback and exits 2. `probe-pr.yml` calls `ht` unguarded, so it is red either way.
- **Message-less failures.** An exception with no message is reported by its type. Before, `contract_row` raised `IndexError` on the empty detail, so `--csv` printed a traceback.
- **Docs.** `AGENTS.md`, `docs/adapting-a-model.md`, and the evaluate-model skill (`SKILL.md`, `references/environment.md`) describe the choice and the exit codes.

No archived row changes: `models/result.csv` has no contract row other than `PASS,OK`.

Left as they were:
- A harness failure while the window is chosen (the probe's reference model or generator raising) is still printed as "adapter contract FAILED". Its exit code, 2, is right; only the wording is.
- When no probe can be consumed, the output gives the closure probe's reasons, labelled as the closure probe's, not every probe's.

## Verification

- `ht validate`: passed, 20 probes, 32 models.
- `pytest`: 381 passed (374 on #44's head). The seven new tests cover:
  - the harness refusing a probe the model cannot consume without invoking the adapter;
  - a window that drops a labelled stretch;
  - the automatic choice for `reference_coupled` (exit 0, an energy probe);
  - an explicit incompatible `--probe` (exit 1, the N/A row);
  - no consumable probe at all (exit 1);
  - a broken, message-less contract (exit 2, `FAIL,ERROR,AssertionError`);
  - an unanticipated crash in `verify-adapter` and `run` (exit 2).
- `ht verify-adapter` on every subprocess model exits 0.
  - The six `rn` models check on `energy/evaporative-partition`.
  - `reference_diurnal_bias` still checks on `energy/surface-energy-closure`.
  - Every other model still checks on `mass/catchment-closure`.
  - The Docker models (`dhbv2`, `google_flood_forecast`, `wflow_sbm`) were not run here. All three are daily and need only `pr, tas, pet`, which the closure probe provides, and it carries no labels a window could drop, so their choice is unchanged.
- `ruff check` on the touched files: no findings beyond those already on #44's head.
- An independent review pass found one medium issue (the crash exit code, fixed above) and four low ones (the doc wording is fixed; the other two are listed under "Left as they were").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
