### PR TITLE
Name what a passing probe exists to score in the archive's detail column

### DIFF
--- a/docs/adapting-a-model.md
+++ b/docs/adapting-a-model.md
@@ -165,7 +165,10 @@ probe, plus one for the adapter contract check when `verify-adapter` is
 given the same `--csv`. For a model that reports only discharge, the
 contract row is the only line saying it was actually built and run on a
 budget probe, because that probe is N/A (INCOMPLETE) before the container is
-started.
+started. Where the criteria ran, a row's `detail` names the ones behind its
+verdict with what each measured: those that failed, or on a pass those the
+probe exists to score, such as `human_abstraction` rather than the closure
+of the natural run.
 
 ## 6. Submit it
 

--- a/docs/writing-a-probe.md
+++ b/docs/writing-a-probe.md
@@ -225,6 +225,15 @@ run against these four before anything else. `must_fail` pins which criterion do
 the catching, so a probe cannot appear to work while catching things for the
 wrong reason.
 
+On a probe with one case per seed, `must_fail` also decides what the report
+says when a model passes: the `detail` column of `models/result.csv` names
+each criterion it lists, with that criterion's own message, and no other. A
+precondition no baseline is pinned to, such as `closure` declared ahead of
+the identity it protects, is therefore never reported as the probe's result.
+A probe with `variants` reports its paired criteria instead, since
+everything beside them is a precondition checked on the control.
+`tests/test_report_detail.py` pins what every merged probe reports.
+
 The reference models available today:
 
 | Model | What it does | Caught by |

--- a/src/hydroturing/harness.py
+++ b/src/hydroturing/harness.py
@@ -560,6 +560,7 @@ def run_probe(
         reason=reason_for(failing, [], None),
         seeds=seeds,
         criteria=outcomes,
+        headline=list(probe.headline),
         flags=sorted(set(flags)),
         authors=list(probe.authors),
         window_days=days,

--- a/src/hydroturing/report.py
+++ b/src/hydroturing/report.py
@@ -24,6 +24,7 @@ from hydroturing.scoring import (
     NOT_SCORED,
     OK,
     PASS,
+    CriterionOutcome,
     ModelReport,
     ProbeOutcome,
 )
@@ -159,7 +160,8 @@ def to_markdown(report: ModelReport) -> str:
         "| --- | --- | --- | --- | --- |",
     ]
     for probe in report.probes:
-        detail = _detail(probe)
+        # A criterion's message can carry a pipe, `|rn|`, which would end the cell.
+        detail = _detail(probe).replace("|", "\\|")
         lines.append(
             f"| `{probe.probe_id}` | {verdict_label(probe.verdict)} | "
             f"{probe.reason} | {window_label(probe)} | {detail} |"
@@ -200,9 +202,20 @@ def _window_line(probe: ProbeOutcome) -> str:
 
 
 def _detail(probe: ProbeOutcome, plain: bool = False) -> str:
-    """One line on where the verdict came from. `plain` drops the markdown."""
+    """One line on where the verdict came from. `plain` drops the markdown.
+
+    A failing probe names the criteria that failed. A passing one names the
+    criteria the probe exists to score (`ProbeOutcome.headline`), each with
+    its own message, so every number in the line says what it measured. A
+    passing paired probe also closes its control run, but that closure is a
+    precondition of the comparison, not its result.
+    """
     code = (lambda s: s) if plain else (lambda s: f"`{s}`")
     bold = (lambda s: s) if plain else (lambda s: f"**{s}**")
+
+    def described(criteria: list[CriterionOutcome]) -> str:
+        return "; ".join(f"{bold(c.name)}: {c.message}" for c in criteria)
+
     if probe.error:
         return probe.error.splitlines()[0][:160]
     parts = []
@@ -212,12 +225,12 @@ def _detail(probe: ProbeOutcome, plain: bool = False) -> str:
         parts.append("; ".join(probe.incompatible))
     failing = [c for c in probe.criteria if not c.passed]
     if failing:
-        parts.append("; ".join(f"{bold(c.name)}: {c.message}" for c in failing))
+        parts.append(described(failing))
     if parts:
         return "; ".join(parts)[:400]
-    closure = next((c for c in probe.criteria if c.name == "closure"), None)
-    if closure and closure.value is not None:
-        return f"residual {closure.value:.3%} of driver"
+    headline = [c for c in probe.criteria if c.name in probe.headline]
+    if headline:
+        return described(headline)[:400]
     return "all criteria pass"
 
 

--- a/src/hydroturing/scoring.py
+++ b/src/hydroturing/scoring.py
@@ -73,6 +73,9 @@ class ProbeOutcome:
     # per seed, the stretch that was actually scored.
     window_days: int | None = None
     windows: list[dict[str, Any]] = field(default_factory=list)
+    # The criteria the probe exists to score, which a pass is reported by.
+    # Empty when the criteria never ran. See ProbeSpec.headline.
+    headline: list[str] = field(default_factory=list)
 
     @property
     def failing(self) -> list[str]:

--- a/src/hydroturing/spec.py
+++ b/src/hydroturing/spec.py
@@ -220,6 +220,27 @@ class ProbeSpec:
         """
         return self.variants[0] if self.variants else None
 
+    @property
+    def headline(self) -> tuple[str, ...]:
+        """The criteria this probe exists to score, in declaration order.
+
+        On a paired probe these are its paired criteria: the variants are run
+        for them alone, and every single-run criterion beside them is scored
+        on the control as a precondition. A probe with one case per seed has
+        no such mark, and its declaration order is no guide either, since a
+        precondition is often listed first. Its gate stands in: the criteria
+        its `must_fail` baselines are declared to trip, which are the
+        failures the probe is shown to catch.
+        """
+        # The package, not criteria.base: importing it is what fills the registry.
+        from hydroturing.criteria import is_paired  # noqa: PLC0415
+
+        paired = tuple(c.name for c in self.criteria if is_paired(c.name))
+        if paired:
+            return paired
+        caught = set(self.must_fail.values())
+        return tuple(c.name for c in self.criteria if c.name in caught)
+
 
 @dataclass(frozen=True)
 class ModelManifest:

--- a/tests/test_report_detail.py
+++ b/tests/test_report_detail.py
@@ -1,0 +1,173 @@
+"""What a report says about a probe that passed.
+
+A failing probe's `detail` names the criteria that failed. A passing one has
+to name what the probe exists to score. On mass/human-abstraction that is the
+paired `human_abstraction`: `closure` there checks only that the natural run
+closes before the two runs are compared, and its residual, standing alone in
+the archive, reads as the probe's result when it is not.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from hydroturing import registry
+from hydroturing.harness import run_model
+from hydroturing.report import to_csv_rows, to_markdown
+from hydroturing.scoring import (
+    FAIL,
+    OK,
+    PASS,
+    VIOLATION,
+    CriterionOutcome,
+    ModelReport,
+    ProbeOutcome,
+)
+from hydroturing.seeds import gate_seeds
+
+# What each merged probe reports a pass by. Pinned in full because a change to
+# a probe's criteria or to its must_fail baselines moves this, and that change
+# should show up in review as a change to what the archive will say.
+HEADLINES = {
+    "energy/evaporative-partition": ("partition_shift",),
+    "energy/latent-heat-et-consistency": ("energy_closure", "flux_identity"),
+    "energy/pet-consistency": ("demand_consistency",),
+    "energy/surface-energy-closure": ("energy_closure_by_phase",),
+    "mass/antecedent-monotonicity": ("antecedent_monotonicity",),
+    "mass/area-invariance": ("invariance",),
+    "mass/catchment-closure": ("closure", "state_bounds", "non_degenerate"),
+    "mass/causality": ("causality",),
+    "mass/dry-down": ("dry_down",),
+    "mass/extreme-rain": ("monotone_response",),
+    "mass/human-abstraction": ("human_abstraction",),
+    "mass/phase-counterfactual": ("phase_invariance",),
+    "mass/precipitation-counterfactual": ("counterfactual_response", "monotone_response"),
+    "mass/resolution-invariance": ("resolution_invariance",),
+    "mass/response-nonnegativity": ("response_nonnegativity",),
+    "mass/runoff-bounds": ("runoff_bounds",),
+    "mass/steady-state": ("steady_state",),
+    "mass/time-origin-invariance": ("invariance",),
+    "mass/warming-response": ("response_sign",),
+    "momentum/routing-conservation": ("routing_conservation",),
+}
+
+
+def _run(model_name: str, probe_id: str):
+    probe = registry.find_probe(probe_id)
+    return run_model(registry.find_model(model_name), [probe], gate_seeds(probe.id, 1))
+
+
+def _criterion(name: str, status: str = "pass", message: str = "", value: float | None = None):
+    return CriterionOutcome(name=name, status=status, message=message, value=value)
+
+
+def _report(*criteria: CriterionOutcome, headline: tuple[str, ...] = ()) -> ModelReport:
+    """One probe's outcome built by hand, for the cases no merged probe produces."""
+    failing = [c.name for c in criteria if not c.passed]
+    outcome = ProbeOutcome(
+        probe_id="mass/example",
+        law="mass",
+        verdict=FAIL if failing else PASS,
+        reason=VIOLATION if failing else OK,
+        criteria=list(criteria),
+        headline=list(headline),
+    )
+    return ModelReport(model_name="example", model_version="1", suite_version="0", probes=[outcome])
+
+
+@pytest.fixture(scope="module")
+def abstraction():
+    return _run("reference_bucket", "mass/human-abstraction")
+
+
+@pytest.fixture(scope="module")
+def latent_heat():
+    return _run("reference_coupled", "energy/latent-heat-et-consistency")
+
+
+@pytest.mark.parametrize("probe_id, headline", sorted(HEADLINES.items()))
+def test_headline_is_what_the_probe_exists_to_score(probe_id, headline):
+    assert registry.find_probe(probe_id).headline == headline
+
+
+def test_every_probe_has_a_headline():
+    """A probe with none could say nothing about a pass but that it passed."""
+    for spec in registry.all_probes():
+        assert spec.headline, f"{spec.id} names no criterion to report a pass by"
+
+
+def test_a_passing_paired_probe_reports_its_paired_criterion(abstraction):
+    outcome = abstraction.probes[0]
+    assert outcome.verdict == PASS, outcome.failing
+    paired = next(c for c in outcome.criteria if c.name == "human_abstraction")
+
+    (row,) = to_csv_rows(abstraction)
+    assert row["detail"] == f"human_abstraction: {paired.message}"
+    # The control run's closure passed as well, and is not what the row reports.
+    assert "closure" not in row["detail"]
+    assert f"**human_abstraction**: {paired.message}" in to_markdown(abstraction)
+
+
+def test_a_passing_single_run_probe_reports_what_its_gate_catches(latent_heat):
+    """Closure is declared first on this probe, as the precondition for the
+    identity, so neither its position nor its name can stand in for the point."""
+    outcome = latent_heat.probes[0]
+    assert outcome.verdict == PASS, outcome.failing
+    by_name = {c.name: c for c in outcome.criteria}
+
+    (row,) = to_csv_rows(latent_heat)
+    assert row["detail"] == (
+        f"energy_closure: {by_name['energy_closure'].message}; "
+        f"flux_identity: {by_name['flux_identity'].message}"
+    )
+
+
+def test_a_pipe_in_a_message_does_not_split_the_markdown_cell(latent_heat):
+    # energy_closure measures its residual against accumulated |rn|.
+    (row,) = [
+        line for line in to_markdown(latent_heat).splitlines()
+        if line.startswith("| `energy/latent-heat-et-consistency` |")
+    ]
+    assert "\\|rn\\|" in row
+    assert len(re.findall(r"(?<!\\)\|", row)) == 6  # the five columns' borders
+
+
+def test_a_failing_probe_still_reports_only_what_failed():
+    report = _run("reference_abstraction_blind", "mass/human-abstraction")
+    outcome = report.probes[0]
+    assert outcome.verdict == FAIL
+    failing = [c for c in outcome.criteria if not c.passed]
+
+    (row,) = to_csv_rows(report)
+    assert row["detail"] == "; ".join(f"{c.name}: {c.message}" for c in failing)
+    assert row["detail"].startswith("human_abstraction: of the prescribed")
+
+
+def test_several_failures_are_all_named_and_the_headline_is_not():
+    report = _report(
+        _criterion("closure", "fail", "cumulative residual 15% of sum_pr"),
+        _criterion("human_abstraction", "pass", "the prescribed 380 mm left the budget"),
+        _criterion("state_bounds", "fail", "mrso leaves [0, 300] on 4 steps"),
+        headline=("human_abstraction",),
+    )
+    (row,) = to_csv_rows(report)
+    assert row["detail"] == (
+        "closure: cumulative residual 15% of sum_pr; state_bounds: mrso leaves [0, 300] on 4 steps"
+    )
+
+
+def test_a_long_passing_detail_is_cut_where_a_failing_one_is():
+    report = _report(_criterion("human_abstraction", message="x" * 500), headline=("human_abstraction",))
+    (row,) = to_csv_rows(report)
+    assert len(row["detail"]) == 400
+    assert row["detail"].startswith("human_abstraction: xxx")
+
+
+def test_an_outcome_without_a_headline_does_not_fall_back_to_closure():
+    """An outcome built outside run_probe carries no headline, and a bare
+    closure residual must not come back as its result."""
+    report = _report(_criterion("closure", message="cumulative residual 0.0210% of sum_pr", value=2.1e-4))
+    (row,) = to_csv_rows(report)
+    assert row["detail"] == "all criteria pass"


### PR DESCRIPTION
## What was wrong

For a passing probe, `report._detail()` fell back to `residual X% of driver` whenever a criterion called `closure` existed. On a paired probe that closure is scored on the control variant alone, as a precondition of the comparison. So every passing row on `mass/human-abstraction`, `mass/precipitation-counterfactual` and `mass/time-origin-invariance` reported the control run's rain closure, and the criterion the probe exists for went unreported. Copilot flagged it on #45: `wflow_sbm,…,mass/human-abstraction,PASS,OK,…,residual 0.021% of driver`.

## What a passing row says now

A passing row names the probe's headline criteria as `name: message`, the same shape a failing row already uses. The other rows are unchanged, byte for byte: failing rows still name what failed, and `N/A` rows still say what the model does not report or cannot consume.

For example, flex_lumped on `mass/human-abstraction`, gate seeds:

```
before: residual 0.000% of driver
after:  human_abstraction: the prescribed 380 mm of abstr left the budget (evspsbl -254.0 mm, mrro -127.6 mm, storage +1.6 mm); residual 0.00% of it (limit 5.00%)
```

`ProbeSpec.headline` decides which criteria are named:

- **Paired probe:** its paired criteria. `spec._check_variants` refuses `case.variants` unless a paired criterion needs them, and every single-run criterion beside them is scored on the control.
- **Single-run probe:** the criteria its `baselines.must_fail` entries trip, in declaration order. That is what the gate shows the probe catches. Declaration order alone would not work, because `energy/latent-heat-et-consistency` declares `closure` first and calls it "a precondition rather than the point".

| Probe | Kind | Reported on a pass |
| --- | --- | --- |
| `energy/evaporative-partition` | paired | `partition_shift` |
| `energy/latent-heat-et-consistency` | single-run | `energy_closure`, `flux_identity` |
| `energy/pet-consistency` | single-run | `demand_consistency` |
| `energy/surface-energy-closure` | single-run | `energy_closure_by_phase` |
| `mass/antecedent-monotonicity` | paired | `antecedent_monotonicity` |
| `mass/area-invariance` | paired | `invariance` |
| `mass/catchment-closure` | single-run | `closure`, `state_bounds`, `non_degenerate` |
| `mass/causality` | paired | `causality` |
| `mass/dry-down` | single-run | `dry_down` |
| `mass/extreme-rain` | paired | `monotone_response` |
| `mass/human-abstraction` | paired | `human_abstraction` |
| `mass/phase-counterfactual` | paired | `phase_invariance` |
| `mass/precipitation-counterfactual` | paired | `counterfactual_response`, `monotone_response` |
| `mass/resolution-invariance` | paired | `resolution_invariance` |
| `mass/response-nonnegativity` | paired | `response_nonnegativity` |
| `mass/runoff-bounds` | single-run | `runoff_bounds` |
| `mass/steady-state` | single-run | `steady_state` |
| `mass/time-origin-invariance` | paired | `invariance` |
| `mass/warming-response` | paired | `response_sign` |
| `momentum/routing-conservation` | single-run | `routing_conservation` |

The coupling to `must_fail` is deliberate but worth knowing about: pinning a new baseline to a precondition of a single-run probe would put that precondition into its passing rows. The table is therefore pinned in full in `tests/test_report_detail.py`, so such an edit shows up in review. `docs/writing-a-probe.md` says so next to `must_fail`.

These options were considered and rejected:

- **`criterion: value` for every criterion:** a value carries neither unit nor direction. `response_sign` passes at `-0.203`, `counterfactual_response` at `1`, `state_bounds` at `0`.
- **Every criterion's message:** 591 characters on latent-heat, cut off by the 400-character cap.
- **A new `probe.yaml` field:** a schema change for the sake of a report column.

The markdown report now escapes `|` in the detail cell. `energy_closure`'s message measures against `|rn|`, which would otherwise end the cell. CSV output is unaffected.

`tests/test_report_detail.py` covers:

- the headline of every merged probe;
- the exact detail of a passing paired probe (`human_abstraction` on reference_bucket);
- the `must_fail` fallback (latent-heat on reference_coupled);
- the escaped pipe;
- failing rows naming every failure and nothing else;
- the 400-character cap on a passing row;
- an outcome with no headline not falling back to a bare closure residual.

`docs/adapting-a-model.md` tells model authors what the column says.

## Archive rows: not rewritten

This PR does not touch `models/`. Rows are written only by `ht run --csv`, so none were hand-edited.

**13 passing rows on `main` report the wrong criterion today:**

| Model | Version | Line in `models/result.csv` | Probes to re-run | Runner |
| --- | --- | --- | --- | --- |
| flex_lumped | 1.0.0 | 184, 194, 224 | time-origin-invariance, precipitation-counterfactual, human-abstraction | subprocess, seconds |
| flex_topo | 1.0.0 | 185, 195, 225 | same three | subprocess, seconds |
| sacsma_snow17 | 1.0.0 | 186, 196, 226 | same three | subprocess, seconds |
| dhbv2 | 0.5.4-hbv2ep100.3 | 188 | time-origin-invariance | docker |
| summa | 4.0.0-f787fa5.4 | 248 | time-origin-invariance | docker |
| wflow_sbm | 1.0.4-ht.2 | 214, 217 | time-origin-invariance, precipitation-counterfactual | superseded by #45 |

**Open model PRs** carry three more each, not yet on `main`:

- **#34 (cwatm):** human-abstraction, precipitation-counterfactual, time-origin-invariance.
- **#45 (wflow_sbm ht.4):** the same three probes.

Once this merges, those two PRs can rebase and re-run their three paired probes before they merge, so nothing wrong lands.

**The other 126 passing rows are not wrong:** 118 read `all criteria pass`, and 8 are `catchment-closure` residuals, where closure is the point. They pick up the new wording whenever their model is next evaluated.

**Proposal:** one follow-up PR per model for flex_lumped, flex_topo, sacsma_snow17, dhbv2 and summa. Each would re-run only the listed probes with `ht run --model <name> --probe <id> --gate-seeds --csv models/result.csv`, then drop the superseded rows.
- **Why a re-run is enough:** on this branch, re-running the three physical models on the three probes with gate seeds reproduces version, verdict, reason, window and seeds for all nine archived rows. Only `detail` changes. So each follow-up records the same evaluation described correctly, not a new result.
- **Replace or append:** dropping the old rows rather than appending beside them is a maintainer's call.

## Verification

- `pytest`: 409 passed, the 381 on `main` plus the 28 in `tests/test_report_detail.py`.
- `ht validate`: passed, 20 probes and 33 models.
- `ht gate`: passed, with output identical to the gate on `main` before this change.
- `ruff` on the touched files: the only new finding is RUF100 on the function-local `# noqa: PLC0415` in `spec.py`. It matches the three identical directives already in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
