### PR TITLE
Kill a container whose run is cut off by an interrupt, SIGTERM or an exception

### DIFF
--- a/src/hydroturing/cli.py
+++ b/src/hydroturing/cli.py
@@ -12,11 +12,16 @@
 from __future__ import annotations
 
 import argparse
+import signal
 import sys
+import threading
 import traceback
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import replace
 import tempfile
 from pathlib import Path
+from typing import NoReturn
 
 from hydroturing import SUITE_VERSION, __version__
 from hydroturing import registry
@@ -465,18 +470,58 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _exit_for_signal(signum, frame) -> NoReturn:
+    # The handler steps aside first, so a second SIGTERM ends the process at
+    # once, the way the first would have without it.
+    signal.signal(signum, signal.SIG_DFL)
+    raise SystemExit(128 + signum)
+
+
+@contextmanager
+def _exit_on_sigterm() -> Iterator[None]:
+    """Turn SIGTERM into SystemExit while a command runs.
+
+    By default SIGTERM ends Python on the spot, and no except or finally
+    clause runs. `kill <pid>`, `timeout` and a service manager stopping a job
+    all send it, and a Docker case under way then kept its container running:
+    the runner never got to kill it, and the docker client either outlived
+    the harness or passed the signal on to a model that need not stop on it.
+    As SystemExit the signal unwinds the way Ctrl+C does. The runner kills
+    the container, nothing records the case as a harness ERROR, and a run
+    stopped before its report is written archives no rows. The process exits
+    143, the status a shell reports for a process SIGTERM ended.
+
+    Only the default disposition is taken over, and it is put back when the
+    command ends, so a caller that ignores or handles SIGTERM itself, or that
+    calls main() in-process as the tests do, keeps what it had.
+    """
+    if (
+        threading.current_thread() is not threading.main_thread()
+        or signal.getsignal(signal.SIGTERM) != signal.SIG_DFL
+    ):
+        yield
+        return
+    signal.signal(signal.SIGTERM, _exit_for_signal)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    try:
-        return args.fn(args)
-    except (KeyError, SpecError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 2
-    except Exception:  # noqa: BLE001 - a crash nothing anticipated is a harness ERROR too
-        # Python exits 1 on an uncaught exception, and CI accepts exit 1 as a
-        # FAIL or an N/A. A crash is neither, so it keeps its traceback and exits 2.
-        traceback.print_exc()
-        return 2
+    with _exit_on_sigterm():
+        try:
+            return args.fn(args)
+        except (KeyError, SpecError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        except Exception:  # noqa: BLE001 - a crash nothing anticipated is a harness ERROR too
+            # Python exits 1 on an uncaught exception, and CI accepts exit 1
+            # as a FAIL or an N/A. A crash is neither, so it keeps its
+            # traceback and exits 2.
+            traceback.print_exc()
+            return 2
 
 
 if __name__ == "__main__":

--- a/src/hydroturing/runner/docker_runner.py
+++ b/src/hydroturing/runner/docker_runner.py
@@ -27,8 +27,8 @@ IMAGE_PREFIX = "hydroturing"
 BUILD_TIMEOUT_S = 1800
 
 # How long `docker kill`, and then `docker rm -f`, may take to end a container
-# that ran past its budget. Either normally returns within seconds; the limit
-# is for a daemon that has stopped answering, so the budget error still
+# whose run was cut off. Either normally returns within seconds; the limit is
+# for a daemon that has stopped answering, so whatever cut the run off still
 # reaches the caller instead of a second hang.
 KILL_TIMEOUT_S = 30
 
@@ -126,8 +126,8 @@ def kill_container(docker: str, name: str) -> None:
     already gone or was not yet created, and one created afterwards is never
     started, because `docker run` starts it from the client, which is dead.
     It takes no CPU, but stays until removed by hand. A command that cannot
-    be run at all is skipped, so the caller's budget error is the one
-    reported.
+    be run at all is skipped, so the caller still reports whatever cut the
+    run off: the budget error, the interrupt or the exception.
     """
     for argv in ([docker, "kill", name], [docker, "rm", "-f", name]):
         try:
@@ -163,8 +163,8 @@ class DockerRunner(Runner):
         request are mounted read-only; only the output directory is writable.
         The image's own working directory is preserved so a relative entrypoint
         resolves exactly as it did when the image was built. The container
-        takes the caller's `name`, so a run cut off at its time budget can be
-        found and killed.
+        takes the caller's `name`, so a run cut off, at its time budget, by an
+        interrupt or by an exception, can be found and killed.
         """
         resources = model.resources or {}
         request_path = (io_dir / "request.json").resolve()
@@ -223,6 +223,18 @@ class DockerRunner(Runner):
             raise RunnerError(
                 f"{model.name}: container exceeded the time budget for {probe.id}"
             ) from None
+        except BaseException:
+            # Any other way the client ends early can leave the container
+            # running too. An interrupt that reaches only the harness does:
+            # subprocess kills the client, and the model never hears of it.
+            # Ctrl+C at a terminal also reaches the client, which forwards it
+            # to the model, but a model need not stop on it. An exception the
+            # harness records as an ERROR leaves the container beside the next
+            # case. So it is killed here as well, and the exception goes on
+            # unchanged: an interrupt still stops the run, and an ERROR keeps
+            # its reason.
+            kill_container(docker, name)
+            raise
 
         if proc.returncode != 0:
             tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-12:]

--- a/src/hydroturing/runner/docker_runner.py
+++ b/src/hydroturing/runner/docker_runner.py
@@ -125,9 +125,12 @@ def kill_container(docker: str, name: str) -> None:
     refused. Nothing is retried. A container neither command finds has
     already gone or was not yet created, and one created afterwards is never
     started, because `docker run` starts it from the client, which is dead.
-    It takes no CPU, but stays until removed by hand. A command that cannot
-    be run at all is skipped, so the caller still reports whatever cut the
-    run off: the budget error, the interrupt or the exception.
+    It takes no CPU, but stays until removed by hand. The client is still
+    alive only when a signal landed while subprocess was starting it, a
+    window well under a millisecond, and that client can go on to start its
+    container. A command that cannot be run at all is skipped, so the caller
+    still reports whatever cut the run off: the budget error, the interrupt
+    or the exception.
     """
     for argv in ([docker, "kill", name], [docker, "rm", "-f", name]):
         try:
@@ -228,11 +231,12 @@ class DockerRunner(Runner):
             # running too. An interrupt that reaches only the harness does:
             # subprocess kills the client, and the model never hears of it.
             # Ctrl+C at a terminal also reaches the client, which forwards it
-            # to the model, but a model need not stop on it. An exception the
-            # harness records as an ERROR leaves the container beside the next
-            # case. So it is killed here as well, and the exception goes on
-            # unchanged: an interrupt still stops the run, and an ERROR keeps
-            # its reason.
+            # to the model, but a model need not stop on it. `ht` turns
+            # SIGTERM into SystemExit, which arrives here the same way. An
+            # exception the harness records as an ERROR leaves the container
+            # beside the next case. So it is killed here as well, and the
+            # exception goes on unchanged: an interrupt still stops the run,
+            # and an ERROR keeps its reason.
             kill_container(docker, name)
             raise
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -615,6 +615,104 @@ esac""")
     assert not (calls / "rm").exists()
 
 
+def test_sigterm_to_the_harness_kills_its_container_before_it_exits(tmp_path):
+    """SIGTERM's default action ends Python without running the runner's
+    cleanup, so `kill <pid>` or `timeout` left the container running, and its
+    docker client with it. `ht` turns SIGTERM into an exit that unwinds the
+    way Ctrl+C does: the container is killed by name, the client is gone, and
+    the process exits 143. The signal goes to the harness alone, as `kill
+    <pid>` sends it, so nothing but the harness can end the client."""
+    import os
+    import shlex
+    import signal
+    import subprocess
+    import sys
+    import time
+    from pathlib import Path
+
+    import hydroturing
+
+    calls = tmp_path / "calls"
+    calls.mkdir()
+    log = shlex.quote(str(calls))
+    # The record is renamed into place, so it exists only once it is complete
+    # and `docker run` is about to sleep.
+    fake_docker(tmp_path, f"""case "$1" in
+  info) echo 28.5.2 ;;
+  run) printf '%s\\n' "$@" > {log}/run.tmp; mv {log}/run.tmp {log}/run; exec sleep 30 ;;
+  kill) printf '%s\\n' "$@" > {log}/kill ;;
+  rm) printf '%s\\n' "$@" > {log}/rm ;;
+esac""")
+    env = dict(os.environ)
+    env["PATH"] = f"{tmp_path}{os.pathsep}{env.get('PATH', '')}"
+    src = str(Path(hydroturing.__file__).resolve().parents[1])
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [src, env.get("PYTHONPATH")]))
+    output = tmp_path / "ht.log"
+    archive = tmp_path / "result.csv"
+
+    with output.open("w") as out:
+        # A session of its own, so the harness's process group holds the
+        # harness, what it started, and nothing else.
+        harness = subprocess.Popen(
+            [sys.executable, "-m", "hydroturing.cli", "run", "--model", "reference_bucket",
+             "--runner", "docker", "--probe", "mass/catchment-closure", "--seed", "1",
+             "--workdir", str(tmp_path / "io"), "--csv", str(archive)],
+            env=env, stdout=out, stderr=subprocess.STDOUT, start_new_session=True,
+        )
+        try:
+            deadline = time.monotonic() + 60
+            while not (calls / "run").exists():
+                assert harness.poll() is None, output.read_text()
+                assert time.monotonic() < deadline, "the harness never reached docker run"
+                time.sleep(0.05)
+            harness.send_signal(signal.SIGTERM)
+            assert harness.wait(timeout=60) == 128 + signal.SIGTERM, output.read_text()
+        finally:
+            if harness.poll() is None:
+                harness.kill()
+                harness.wait()
+            # Whatever is still in the group outlived the harness: the docker
+            # client, if the harness did not end it. Signal 0 only asks.
+            try:
+                os.killpg(harness.pid, 0)
+                left_running = True
+                os.killpg(harness.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                left_running = False
+
+    run = (calls / "run").read_text().splitlines()
+    name = run[run.index("--name") + 1]
+    assert (calls / "kill").read_text().splitlines() == ["kill", name]
+    assert not left_running, "the docker client outlived the harness"
+    assert not archive.exists(), "a terminated run archived rows"
+
+
+@pytest.mark.parametrize("before", ["default", "ignored"])
+def test_cli_takes_over_sigterm_only_from_the_default_and_gives_it_back(monkeypatch, before):
+    """The tests, and any program embedding the harness, call cli.main()
+    in-process. It must leave the process's SIGTERM disposition as it found
+    it, and must not override a caller that ignores SIGTERM on purpose."""
+    import signal
+
+    from hydroturing import cli
+
+    disposition = {"default": signal.SIG_DFL, "ignored": signal.SIG_IGN}[before]
+    during = []
+    monkeypatch.setattr(cli, "cmd_list", lambda args: during.append(signal.getsignal(signal.SIGTERM)) or 0)
+    original = signal.signal(signal.SIGTERM, disposition)
+    try:
+        assert cli.main(["list"]) == 0
+        after = signal.getsignal(signal.SIGTERM)
+    finally:
+        signal.signal(signal.SIGTERM, original)
+
+    if before == "default":
+        assert during == [cli._exit_for_signal]
+    else:
+        assert during == [signal.SIG_IGN]
+    assert after == disposition
+
+
 def test_submitted_model_cannot_request_host_subprocess_access(tmp_path):
     import shutil
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -562,6 +562,59 @@ esac""")
         assert (calls / "rm").read_text().splitlines() == ["rm", "-f", name]
 
 
+@pytest.mark.parametrize(
+    "cut_off",
+    [KeyboardInterrupt(), RuntimeError("the docker client broke")],
+    ids=["interrupted", "crashed"],
+)
+def test_container_whose_run_is_cut_off_by_an_exception_is_killed(monkeypatch, tmp_path, cut_off):
+    """A timeout is not the only way the docker client can end with its
+    container still running. An interrupt ends it too, and so does any
+    exception the harness records as an ERROR before it starts the next case.
+    Sent to the harness alone, an interrupt left google_flood_forecast's
+    container computing for 34 s more, writing into an output directory no
+    one read. The container is killed by name either way, and the exception
+    goes on unchanged: an interrupt still has to stop the run, and an ERROR
+    keeps its reason."""
+    import shlex
+
+    from hydroturing.runner import docker_runner
+
+    calls = tmp_path / "calls"
+    calls.mkdir()
+    log = shlex.quote(str(calls))
+    docker = fake_docker(tmp_path, f"""case "$1" in
+  kill) printf '%s\\n' "$@" > {log}/kill ;;
+  rm) printf '%s\\n' "$@" > {log}/rm ;;
+esac""")
+    monkeypatch.setattr(docker_runner, "require_docker", lambda: docker)
+
+    # Raising in place of `docker run` stands in for an exception that arrives
+    # while it is in flight; the build before it and the kill after it reach
+    # the fake docker.
+    real_run = docker_runner.subprocess.run
+    run = []
+
+    def cut_off_run(argv, **kwargs):
+        if argv[1] == "run":
+            run.extend(argv)
+            raise cut_off
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(docker_runner.subprocess, "run", cut_off_run)
+
+    model = registry.find_model("reference_bucket")
+    probe = registry.find_probe("mass/catchment-closure")
+    with pytest.raises(type(cut_off)) as raised:
+        docker_runner.DockerRunner().invoke(model, probe, tmp_path, tmp_path / "request.json")
+
+    assert raised.value is cut_off
+    name = run[run.index("--name") + 1]
+    assert name.startswith(f"hydroturing-{model.name}-")
+    assert (calls / "kill").read_text().splitlines() == ["kill", name]
+    assert not (calls / "rm").exists()
+
+
 def test_submitted_model_cannot_request_host_subprocess_access(tmp_path):
     import shutil
 


### PR DESCRIPTION
## Problem

#46 names each container `hydroturing-<model>-<uuid>` and kills it when `docker run` passes the probe's `max_runtime_s`. That is the only path that kills. Any other way out of `subprocess.run(docker run ...)` still leaves the container running in the daemon until it finishes by itself:

- **An interrupt that reaches only the harness.** CPython's `subprocess.run` answers a KeyboardInterrupt by waiting 0.25 s and then sending SIGKILL to the docker client. The client cannot forward SIGKILL, so the model never learns of the interrupt.
- **An exception the harness records as an ERROR.** `run_probe` catches `Exception` around `runner.run` (`harness.py:532`) and moves on, so the next case starts beside the old container.
- **SIGTERM to the harness.** `kill <pid>`, `timeout` and service managers send it. By default it ends Python on the spot, before any except or finally clause can run.

A leftover container takes CPU on a shared host and inflates the timings of later cases, including the timeouts that decide ERROR verdicts. It can also write into an `/io/output` directory the harness has already abandoned. The live check below shows both.

The timed-out LISFLOOD containers seen on 2026-09-11 went down the timeout path. #46 fixed that path, and LISFLOOD (#52, merged as 12cbaaa) was evaluated from a branch that already included it: 2ed5cb8, cdeb0d7 and 89f2f14 are ancestors of that branch's head, 08531c0. This PR covers the remaining ways out, and is rebased onto 12cbaaa.

## Change

- `DockerRunner.invoke` adds `except BaseException:` after the existing `except subprocess.TimeoutExpired:`. It calls the same `kill_container(docker, name)` (`docker kill`, then `docker rm -f` if that fails) and re-raises the original exception unchanged.
  - Ctrl+C still stops the run.
  - A harness ERROR keeps the reason text it reports today.
- `cli.main` turns SIGTERM into `SystemExit(143)` while a command runs, so SIGTERM reaches that same clause.
  - A run terminated before its report is written records no harness ERROR and archives no rows. The process exits 143, the status a shell reports for a process ended by SIGTERM.
  - After the first SIGTERM the handler restores the default, so a second SIGTERM ends the process at once.
  - The handler is installed only on the main thread, and only while SIGTERM has its default disposition. The default is restored when the command ends, because tests call `cli.main()` in-process.
- The timeout path and its `RunnerError` message are unchanged.
- The container name is unchanged.
- The isolation flags in `DockerRunner.command` are unchanged.
- The comments and docstrings that described the kill as timeout-only now cover interrupts and exceptions. The new clause's comment also names SIGTERM.

## Verification

- `pytest`: 417 passed.
- `ht validate`: `validation passed: 20 probe(s), 35 model(s), suite 0.1.0` (on the rebased tree, which includes lisflood).
- `ht gate`: `GATE PASSED`, run again after the `cli.main` change, which wraps every command including the gate. The gate's reference models declare `runner: subprocess`, so it never reaches the Docker runner.
- `ruff check` on the three touched files: the same findings as on main, none in the new lines.
- **New test** `test_container_whose_run_is_cut_off_by_an_exception_is_killed` in `tests/test_harness.py`, parametrized as `interrupted` (KeyboardInterrupt) and `crashed` (RuntimeError).
  - `subprocess.run` raises in place of `docker run`, which stands in for an exception that arrives while the run is in flight. The build and the kill go to the fake docker from the existing `fake_docker` helper.
  - The test asserts that the kill is `kill <name>` with the `--name` the run was given, that no `rm` follows, and that the same exception object propagates.
  - Against main's runner both cases fail, because no kill is recorded.
- **New SIGTERM tests**, also in `tests/test_harness.py`:
  - `test_sigterm_to_the_harness_kills_its_container_before_it_exits` runs `python -m hydroturing.cli run --model reference_bucket --runner docker` against a fake docker on PATH. Once the fake `docker run` is in flight, it sends SIGTERM to the harness pid alone. It asserts exit 143, a `kill <name>` with the run's container name, that nothing is left in the harness's process group (so the fake client did not outlive it), and that `--csv` wrote no rows.
  - `test_cli_takes_over_sigterm_only_from_the_default_and_gives_it_back` checks that `cli.main()` leaves a default or ignored SIGTERM as it found it.
  - Against 60b5c03, the first fails because the harness dies with -15. The default case of the second fails because no handler is installed.
- **Live check on Docker Desktop 28.5.2** (`DOCKER_CONTEXT=desktop-linux`) with the existing `hydroturing/google_flood_forecast:0.1.0-828dfc5` image on `mass/dry-down`, seed 1. The build is skipped, and the io dir is under `$HOME`.
  - SIGINT was sent 2 s after the container started, either to the harness process alone or to its whole process group, as Ctrl+C at a terminal does.
  - A container counts only if its mounts are under that run's own workdir.
  - This first check drove `harness.run_probe` from a small script that exits 130 on KeyboardInterrupt, so "130" below is that script's status. Through `ht` itself, a SIGINT ends the process by the signal (-2), as the last row of the SIGTERM table shows.

  | runner | SIGINT to | harness exit | this run's container 2 / 5 / 10 s after the harness exited | `run.json` in the abandoned output dir |
  |---|---|---|---|---|
  | main | harness only | 130, 0.3 s after SIGINT | running / running / running; it ended by itself 34 s after SIGINT | written |
  | main | process group | 130, 0.6 s | none / none / none | none |
  | this branch | harness only | 130, 0.4 s | none / none / none | none |
  | this branch | process group | 130, 0.4 s | none / none / none | none |

  On main, a terminal Ctrl+C already ended this container. The docker client forwards SIGINT to the model (`--sig-proxy` defaults to true), and this Python adapter stops on it. A model that ignores or swallows SIGINT would not stop, and the kill covers that case too.
- **Live SIGTERM check.** Same image, probe and seed, but driven through `cli.main` (`ht run --probe mass/dry-down --seed 1`), with the signal sent 2 s after the container started. The "60b5c03" rows use the previous commit on this branch, which has no SIGTERM handler.

  | code | signal sent to | harness exit | docker client after the harness exited | container 2 / 5 / 10 s after | `run.json` in the abandoned output dir |
  |---|---|---|---|---|---|
  | 60b5c03 | SIGTERM, harness only | died of the signal (-15) at once | alive | running / running / running; it ended by itself 33 s after the signal | written |
  | 60b5c03 | SIGTERM, process group | died of the signal (-15) at once | alive | running / running / running; it ended by itself 27 s after the signal | written |
  | this branch | SIGTERM, harness only | 143, 0.1 s after the signal | gone | none / none / none | none |
  | this branch | SIGTERM, process group | 143, 0.2 s | gone | none / none / none | none |
  | this branch | SIGINT, harness only | died of SIGINT (-2), 0.6 s | gone | none / none / none | none |

  - A SIGTERM sent to the whole group did not stop this adapter, whereas SIGINT does. The client stayed alive, and so did the container.
  - The last row shows that Ctrl+C through the CLI still ends the run and leaves nothing behind.

## Review

A separate code review before this PR approved the change with no high or medium findings. It raised four low notes:

- **Fixed:** three comments still named only the budget error or interrupts.
- **Fixed:** the test's comment said the exception arrives while `docker run` is in flight. It is raised in place of `docker run`.
- **Not changed:** a second Ctrl+C during the kill escapes `kill_container` and skips the `rm -f` fallback. The container is then left as it would be on main, and the kill waits at most 30 s per command only on a daemon that has stopped answering.
- **Addressed in the second commit:** SIGTERM to the harness.

A second review, of the SIGTERM commit, also approved it with no high or medium findings. From its low notes:

- **Fixed:** the fake docker's `run` record could be read before it was complete. It is now renamed into place.
- **Fixed:** the check for a leftover client signalled a pid the system might already have reused. It now asks the harness's process group with signal 0.
- **Fixed:**
  - `PYTHONPATH` is prepended to, not replaced.
  - The test also asserts that `--csv` wrote nothing.
  - The runner comment names SIGTERM.
- **Fixed:** the `kill_container` docstring now names the sub-millisecond window in which a signal lands while subprocess is still starting the client. A client caught in that window is not killed and can start its container. The window itself is left as is.
- **Not changed:** a supervisor sees exit 143 rather than death by signal, and systemd counts 143 as a failure unless `SuccessExitStatus=143` is set. No exit-code doc lists 143 either, since it is not a verdict.

## Not covered

- **SIGKILL of the harness, or an interpreter crash.** No code runs. Only a later sweep for leftover `hydroturing-` containers could clean up.
- **SIGHUP**, which is sent when the terminal closes. It still ends the harness without running the cleanup, and this PR does not handle it.
- **An interrupt or SIGTERM during `docker build`.** No container exists yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
